### PR TITLE
feat: add ele-redis-stream tool and stream package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,16 @@ TOOLS_MAIN = ./cmd/ele-tools
 STRESS_BIN = ele-stress
 STRESS_MAIN = ./cmd/ele-stress
 
+REDISSTREAM_BIN = ele-redis-stream
+REDISSTREAM_MAIN = ./cmd/ele-redis-stream
+
 LDFLAGS = -ldflags "-X 'main.TAG=$(TAG)' -X 'main.COMMIT=$(COMMIT)' -X 'main.BLDTIME=$(BLDTIME)' -X 'main.GOVER=$(GOVER)'"
 
-.PHONY: all build apiserver scanner roomserver botserver stat tools stress clean deps lint help
+.PHONY: all build apiserver scanner roomserver botserver stat tools stress redisstream clean deps lint help
 
 all: build
 
-build: apiserver scanner roomserver botserver stat tools stress
+build: apiserver scanner roomserver botserver stat tools stress redisstream
 
 apiserver: $(BIN_DIR)
 	@echo "Building $(APISERVER_BIN)..."
@@ -79,12 +82,17 @@ stress: $(BIN_DIR)
 	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/$(STRESS_BIN) $(STRESS_MAIN)
 	@echo "Build completed: $(BIN_DIR)/$(STRESS_BIN)"
 
+redisstream: $(BIN_DIR)
+	@echo "Building $(REDISSTREAM_BIN)..."
+	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/$(REDISSTREAM_BIN) $(REDISSTREAM_MAIN)
+	@echo "Build completed: $(BIN_DIR)/$(REDISSTREAM_BIN)"
+
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)
 
 clean:
 	@echo "Cleaning build files..."
-	rm -rf $(BIN_DIR)/$(APISERVER_BIN) $(BIN_DIR)/$(SCANNER_BIN) $(BIN_DIR)/$(ROOMSERVER_BIN) $(BIN_DIR)/$(BOTSERVER_BIN) $(BIN_DIR)/$(STAT_BIN) $(BIN_DIR)/$(TOOLS_BIN) $(BIN_DIR)/$(STRESS_BIN)
+	rm -rf $(BIN_DIR)/$(APISERVER_BIN) $(BIN_DIR)/$(SCANNER_BIN) $(BIN_DIR)/$(ROOMSERVER_BIN) $(BIN_DIR)/$(BOTSERVER_BIN) $(BIN_DIR)/$(STAT_BIN) $(BIN_DIR)/$(TOOLS_BIN) $(BIN_DIR)/$(STRESS_BIN) $(BIN_DIR)/$(REDISSTREAM_BIN)
 	@echo "Clean completed"
 
 deps:
@@ -112,6 +120,7 @@ help:
 	@echo "  stat          - Build ele-stat only"
 	@echo "  tools         - Build ele-tools only"
 	@echo "  stress        - Build ele-stress only"
+	@echo "  redisstream   - Build ele-redis-stream only (Redis Stream test tool)"
 	@echo ""
 	@echo "Other:"
 	@echo "  clean         - Clean build files"

--- a/cmd/ele-redis-stream/README.md
+++ b/cmd/ele-redis-stream/README.md
@@ -1,0 +1,100 @@
+# ele-redis-stream
+
+Redis Stream 测试工具，用于 room_events 流的生产、消费和裁剪。基于 `stream` 包抽象，底层使用 Redis 实现。
+
+## 构建
+
+```bash
+make redisstream
+# 输出: bin/ele-redis-stream
+```
+
+## 配置
+
+通过 `-c` 指定配置文件，需包含 `redis` 段：
+
+```yaml
+redis:
+  address: localhost:6379
+  password: ""
+  size: 10
+
+log:
+  level: info
+```
+
+## 子命令
+
+### consume - 消费
+
+从 `room_events` 流中读取事件并输出到控制台。
+
+```bash
+./bin/ele-redis-stream consume -c config.yaml
+./bin/ele-redis-stream consume -c config.yaml -b 2000   # block 超时 2000ms
+```
+
+| 参数 | 说明 | 默认 |
+|------|------|------|
+| `-c, --config` | 配置文件路径 | config.yaml |
+| `-b, --block` | XREAD 阻塞超时 (ms) | 1000 |
+
+### produce - 生产
+
+向 `room_events` 流写入测试事件。
+
+```bash
+./bin/ele-redis-stream produce -c config.yaml
+./bin/ele-redis-stream produce -c config.yaml -n 10 -i 1s   # 发送 10 条，间隔 1 秒
+./bin/ele-redis-stream produce -c config.yaml -t my_topic   # 指定 topic
+```
+
+| 参数 | 说明 | 默认 |
+|------|------|------|
+| `-c, --config` | 配置文件路径 | config.yaml |
+| `-t, --topic` | 主题 | test_topic_0x123_0x456 |
+| `-i, --interval` | 发送间隔 | 1s |
+| `-n, --count` | 发送条数 (0=持续直到 Ctrl+C) | 0 |
+
+### trim - 裁剪
+
+删除超过指定时间的旧条目，执行前会打印将被删除的内容。
+
+```bash
+./bin/ele-redis-stream trim -c config.yaml -m 1h
+./bin/ele-redis-stream trim -c config.yaml -m 10s -n   # dry-run，不实际删除
+./bin/ele-redis-stream trim -c config.yaml -s room_events -m 30m
+```
+
+| 参数 | 说明 | 默认 |
+|------|------|------|
+| `-c, --config` | 配置文件路径 | config.yaml |
+| `-m, --max-age` | 删除超过此时间的条目 (如 1h, 30m, 10s) | 1h |
+| `-s, --stream` | 流名称 | room_events |
+| `-n, --dry-run` | 仅预览，不执行删除 | false |
+
+## 使用示例
+
+```bash
+# 终端 1: 启动消费者
+./bin/ele-redis-stream consume -c stream_consumer_config.yaml
+
+# 终端 2: 生产 5 条测试消息
+./bin/ele-redis-stream produce -c stream_config.yaml -n 5 -i 500ms
+
+# 查看redis里的消息
+redis-cli XRANGE room_events - +
+
+# 裁剪 1 小时前的数据（先 dry-run 预览）
+./bin/ele-redis-stream trim -c stream_config.yaml -m 30s -n
+./bin/ele-redis-stream trim -c stream_config.yaml -m 30s
+```
+
+## Redis 版本
+
+- **XTRIM MINID** 需要 Redis 6.2+
+- Redis 6.0 及以下会自动回退到 XDEL 逐条删除
+
+## 消息格式
+
+流中每条消息包含字段：`topic`、`payload`（base64 编码的 protobuf）、`ts`。与 Room Server PubSub.Publish 格式一致。

--- a/cmd/ele-redis-stream/consume.go
+++ b/cmd/ele-redis-stream/consume.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/CryptoElementals/common/config"
+	"github.com/CryptoElementals/common/log"
+	"github.com/CryptoElementals/common/redis"
+	"github.com/CryptoElementals/common/stream"
+	"google.golang.org/protobuf/encoding/protojson"
+	gproto "google.golang.org/protobuf/proto"
+
+	pb "github.com/CryptoElementals/common/rpc/proto"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultStreamName = "room_events"
+	chanBufferSize    = 4096
+	forwardTimeout    = 5 * time.Second
+	defaultBlockMs    = 1000 // shorter block = faster ctx check on shutdown
+)
+
+var (
+	configPath string
+	blockMs    int
+)
+
+func init() {
+	rootCmd.AddCommand(consumeCmd)
+	consumeCmd.Flags().StringVarP(&configPath, "config", "c", "config.yaml", "config file path (for Redis, Log)")
+	consumeCmd.Flags().IntVarP(&blockMs, "block", "b", defaultBlockMs, "XREAD block timeout in ms (shorter = faster shutdown, more round-trips when idle)")
+}
+
+var consumeCmd = &cobra.Command{
+	Use:   "consume",
+	Short: "Start Redis Stream consumer",
+	Long: `Consume events from room_events with optimized logic (channel decoupling, async, timeout protection),
+output to console.`,
+	RunE: runConsume,
+}
+
+type bridgeMsg struct {
+	topic string
+	msg   *pb.Message
+}
+
+// bridgeConfig contains Redis and Log only, reuses API Server config.yaml structure
+type bridgeConfig struct {
+	LogCfg   log.Config   `mapstructure:"log"`
+	RedisCfg redis.Config `mapstructure:"redis"`
+}
+
+func runConsume(cmd *cobra.Command, args []string) error {
+	cfg := &bridgeConfig{}
+	if err := config.InitConfig(configPath, cfg); err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if cfg.LogCfg.Level == "" {
+		cfg.LogCfg.Level = "info"
+	}
+	if cfg.RedisCfg.Address == "" {
+		cfg.RedisCfg.Address = "localhost:6379"
+	}
+	if cfg.RedisCfg.Size == 0 {
+		cfg.RedisCfg.Size = 10
+	}
+
+	if err := log.InitGlobalLogger(&cfg.LogCfg); err != nil {
+		return fmt.Errorf("failed to init logger: %w", err)
+	}
+
+	if err := redis.Init(&cfg.RedisCfg); err != nil {
+		return fmt.Errorf("failed to init Redis: %w", err)
+	}
+
+	st, err := stream.NewRedisStream()
+	if err != nil {
+		return fmt.Errorf("failed to create stream: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan bridgeMsg, chanBufferSize)
+
+	// Consumer: receive from channel and process async (simulate forward, output to console)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case m, ok := <-ch:
+				if !ok {
+					return
+				}
+				handleMsg(m)
+			}
+		}
+	}()
+
+	// Producer: stream Read loop
+	go func() {
+		log.Infof("Redis stream consumer started, stream=%s, block=%dms", defaultStreamName, blockMs)
+		defer log.Infof("Redis stream consumer stopped")
+		defer close(ch)
+
+		block := blockMs
+		if block < 100 {
+			block = 100
+		}
+
+		lastID := "$"
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			entries, err := st.Read(ctx, defaultStreamName, lastID, block)
+			if err != nil {
+				log.Errorf("stream read error: %v", err)
+				time.Sleep(500 * time.Millisecond)
+				continue
+			}
+
+			for _, e := range entries {
+				lastID = e.ID
+				if e.Topic == "" || len(e.Payload) == 0 {
+					continue
+				}
+
+				var pbMsg pb.Message
+				if err := gproto.Unmarshal(e.Payload, &pbMsg); err != nil {
+					continue
+				}
+
+				select {
+				case ch <- bridgeMsg{topic: e.Topic, msg: &pbMsg}:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+
+	return waitForSignal(cancel)
+}
+
+// handleMsg simulates forwardToClient: async with timeout protection
+func handleMsg(m bridgeMsg) {
+	// Test service: output to stdout and log
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		eventType := "unknown"
+		if m.msg.Event != nil {
+			eventType = m.msg.Event.Type.String()
+		}
+		line := fmt.Sprintf("[%s] topic=%s event=%s msgId=%s publisher=%s ts=%d",
+			time.Now().Format("15:04:05.000"), m.topic, eventType, m.msg.MessageId, m.msg.PublisherId, m.msg.Timestamp)
+		fmt.Println(line)
+		log.Infof("%s", line)
+		if len(m.msg.Metadata) > 0 {
+			meta := fmt.Sprintf("  metadata: %v", m.msg.Metadata)
+			fmt.Println(meta)
+		}
+		// Full message as JSON (indented for readability)
+		opts := protojson.MarshalOptions{Multiline: true, Indent: "  "}
+		if b, err := opts.Marshal(m.msg); err == nil {
+			payload := fmt.Sprintf("  payload:\n%s", string(b))
+			fmt.Println(payload)
+		}
+		fmt.Println("---")
+	}()
+	select {
+	case <-done:
+	case <-time.After(forwardTimeout):
+		log.Warnf("handle msg timeout: topic=%s", m.topic)
+	}
+}
+
+func waitForSignal(cancel context.CancelFunc) error {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	<-sigCh
+	log.Info("Received shutdown signal")
+	cancel()
+	return nil
+}

--- a/cmd/ele-redis-stream/main.go
+++ b/cmd/ele-redis-stream/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "ele-redis-stream",
+	Short: "Redis Stream test tool",
+	Long: `Redis Stream test tool with producer and consumer:
+
+  consume  - Consumer: consume events from room_events and output to console (optimized: channel decoupling, async, timeout)
+  produce  - Producer: write test events to room_events
+  trim     - Trim stream: remove entries older than max-age (e.g. 1h)
+
+Redis config required. Use -c config.yaml to specify config file.`,
+}

--- a/cmd/ele-redis-stream/produce.go
+++ b/cmd/ele-redis-stream/produce.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/CryptoElementals/common/config"
+	"github.com/CryptoElementals/common/redis"
+	"github.com/CryptoElementals/common/stream"
+	"github.com/google/uuid"
+	gproto "google.golang.org/protobuf/proto"
+
+	pb "github.com/CryptoElementals/common/rpc/proto"
+	"github.com/spf13/cobra"
+)
+
+var (
+	produceTopic    string
+	produceInterval time.Duration
+	produceCount    int
+)
+
+func init() {
+	rootCmd.AddCommand(produceCmd)
+	produceCmd.Flags().StringVarP(&configPath, "config", "c", "config.yaml", "config file path")
+	produceCmd.Flags().StringVarP(&produceTopic, "topic", "t", "test_topic_0x123_0x456", "test topic")
+	produceCmd.Flags().DurationVarP(&produceInterval, "interval", "i", time.Second, "send interval (0 = send once)")
+	produceCmd.Flags().IntVarP(&produceCount, "count", "n", 0, "message count (0 = send until Ctrl+C)")
+}
+
+var produceCmd = &cobra.Command{
+	Use:   "produce",
+	Short: "Producer: write test events to room_events",
+	Long: `Write test events to Redis Stream room_events. Format matches Room Server PubSub.Publish.
+Use with consume for end-to-end testing.`,
+	RunE: runProduce,
+}
+
+func runProduce(cmd *cobra.Command, args []string) error {
+	cfg := &bridgeConfig{}
+	if err := config.InitConfig(configPath, cfg); err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if cfg.RedisCfg.Address == "" {
+		cfg.RedisCfg.Address = "localhost:6379"
+	}
+	if cfg.RedisCfg.Size == 0 {
+		cfg.RedisCfg.Size = 10
+	}
+
+	if err := redis.Init(&cfg.RedisCfg); err != nil {
+		return fmt.Errorf("failed to init Redis: %w", err)
+	}
+
+	st, err := stream.NewRedisStream()
+	if err != nil {
+		return fmt.Errorf("failed to create stream: %w", err)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	ctx := context.Background()
+	sent := 0
+	for {
+		select {
+		case <-sigCh:
+			fmt.Printf("Produced %d messages, exiting\n", sent)
+			return nil
+		default:
+		}
+
+		msg := &pb.Message{
+			MessageId:   uuid.New().String(),
+			Topic:       produceTopic,
+			Timestamp:   time.Now().Unix(),
+			PublisherId: "ele-redis-stream-produce",
+			Event: &pb.Event{
+				Type: pb.EventType_TYPE_GAME_PHASE_SYNC,
+				Event: &pb.Event_GamePhase{
+					GamePhase: &pb.GamePhase{
+						GameType: pb.GameType_PVP,
+						GameID:   1,
+					},
+				},
+			},
+		}
+
+		b, err := gproto.Marshal(msg)
+		if err != nil {
+			return fmt.Errorf("marshal failed: %w", err)
+		}
+
+		_, err = st.Publish(ctx, defaultStreamName, msg.Topic, b, msg.Timestamp)
+		if err != nil {
+			return fmt.Errorf("publish failed: %w", err)
+		}
+
+		sent++
+		fmt.Printf("[%s] produced #%d topic=%s msgId=%s\n", time.Now().Format("15:04:05.000"), sent, produceTopic, msg.MessageId)
+
+		if produceCount > 0 && sent >= produceCount {
+			return nil
+		}
+
+		if produceInterval > 0 {
+			select {
+			case <-sigCh:
+				fmt.Printf("Produced %d messages, exiting\n", sent)
+				return nil
+			case <-time.After(produceInterval):
+			}
+		}
+	}
+}

--- a/cmd/ele-redis-stream/trim.go
+++ b/cmd/ele-redis-stream/trim.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/CryptoElementals/common/config"
+	"github.com/CryptoElementals/common/redis"
+	"github.com/CryptoElementals/common/stream"
+	pb "github.com/CryptoElementals/common/rpc/proto"
+	"google.golang.org/protobuf/encoding/protojson"
+	gproto "google.golang.org/protobuf/proto"
+	"github.com/spf13/cobra"
+)
+
+var (
+	trimMaxAge time.Duration
+	trimStream string
+	trimDryRun bool
+)
+
+func init() {
+	rootCmd.AddCommand(trimCmd)
+	trimCmd.Flags().StringVarP(&configPath, "config", "c", "config.yaml", "config file path")
+	trimCmd.Flags().DurationVarP(&trimMaxAge, "max-age", "m", time.Hour, "remove entries older than this (e.g. 1h, 30m, 10s)")
+	trimCmd.Flags().StringVarP(&trimStream, "stream", "s", defaultStreamName, "stream name")
+	trimCmd.Flags().BoolVarP(&trimDryRun, "dry-run", "n", false, "show what would be trimmed without deleting")
+}
+
+// formatPayload formats protobuf bytes as indented JSON, or a fallback string on error
+func formatPayload(payload []byte) string {
+	if len(payload) == 0 {
+		return "(empty)"
+	}
+	var msg pb.Message
+	if err := gproto.Unmarshal(payload, &msg); err != nil {
+		return fmt.Sprintf("(proto unmarshal error: %v)", err)
+	}
+	opts := protojson.MarshalOptions{Multiline: true, Indent: "    "}
+	b, err := opts.Marshal(&msg)
+	if err != nil {
+		return fmt.Sprintf("(json marshal error: %v)", err)
+	}
+	return string(b)
+}
+
+var trimCmd = &cobra.Command{
+	Use:   "trim",
+	Short: "Trim stream: remove entries older than max-age",
+	Long: `Remove entries from Redis Stream older than the specified max-age.
+Uses XTRIM MINID - stream IDs are milliseconds-since-epoch, so we compute
+the cutoff ID from (now - maxAge).
+
+Example: trim -m 1h  removes entries older than 1 hour`,
+	RunE: runTrim,
+}
+
+func runTrim(cmd *cobra.Command, args []string) error {
+	cfg := &bridgeConfig{}
+	if err := config.InitConfig(configPath, cfg); err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if cfg.RedisCfg.Address == "" {
+		cfg.RedisCfg.Address = "localhost:6379"
+	}
+	if cfg.RedisCfg.Size == 0 {
+		cfg.RedisCfg.Size = 10
+	}
+
+	if err := redis.Init(&cfg.RedisCfg); err != nil {
+		return fmt.Errorf("failed to init Redis: %w", err)
+	}
+
+	st, err := stream.NewRedisStream()
+	if err != nil {
+		return fmt.Errorf("failed to create stream: %w", err)
+	}
+
+	ctx := context.Background()
+	cutoff := time.Now().Add(-trimMaxAge)
+	minID := fmt.Sprintf("%d-0", cutoff.UnixMilli())
+
+	entries, err := st.Range(ctx, trimStream, "-", minID)
+	if err != nil {
+		return fmt.Errorf("range failed: %w", err)
+	}
+
+	var toDelete []stream.Entry
+	for _, e := range entries {
+		if e.ID < minID {
+			toDelete = append(toDelete, e)
+		}
+	}
+
+	if trimDryRun {
+		lenBefore, err := st.Len(ctx, trimStream)
+		if err != nil {
+			return fmt.Errorf("len failed: %w", err)
+		}
+		fmt.Printf("Stream: %s\n", trimStream)
+		fmt.Printf("Max age: %s (cutoff: %s)\n", trimMaxAge, cutoff.Format(time.RFC3339))
+		fmt.Printf("MINID threshold: %s\n", minID)
+		fmt.Printf("Entries before trim: %d (would delete %d)\n", lenBefore, len(toDelete))
+		for _, e := range toDelete {
+			fmt.Printf("  [%s] topic=%s ts=%d\n", e.ID, e.Topic, e.Timestamp)
+			fmt.Printf("    payload:\n%s\n", formatPayload(e.Payload))
+		}
+		fmt.Println("Dry run - no changes made")
+		return nil
+	}
+
+	for _, e := range toDelete {
+		fmt.Printf("[%s] topic=%s ts=%d\n", e.ID, e.Topic, e.Timestamp)
+		fmt.Printf("  payload:\n%s\n", formatPayload(e.Payload))
+	}
+
+	expected := len(toDelete)
+	deleted, err := st.Trim(ctx, trimStream, trimMaxAge)
+	if err != nil {
+		return fmt.Errorf("trim failed: %w", err)
+	}
+	if expected > 0 && deleted < expected {
+		fmt.Fprintf(os.Stderr, "ERROR: trim deleted %d entries, expected %d (stream=%s)\n", deleted, expected, trimStream)
+	}
+
+	fmt.Printf("Trimmed %d entries from %s (older than %s)\n", deleted, trimStream, trimMaxAge)
+	return nil
+}

--- a/stream/redis_stream.go
+++ b/stream/redis_stream.go
@@ -1,0 +1,219 @@
+package stream
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/CryptoElementals/common/redis"
+	redigo "github.com/gomodule/redigo/redis"
+)
+
+var _ Stream = (*RedisStream)(nil)
+
+type RedisStream struct{}
+
+// NewRedisStream returns a Redis-backed Stream. Requires redis.Init to be called first.
+func NewRedisStream() (Stream, error) {
+	if err := redis.Ping(); err != nil {
+		return nil, err
+	}
+	return &RedisStream{}, nil
+}
+
+func (r *RedisStream) Publish(ctx context.Context, stream string, topic string, payload []byte, ts int64) (string, error) {
+	pool, err := redis.GetRedigoPool()
+	if err != nil {
+		return "", err
+	}
+	conn := pool.Get()
+	defer conn.Close()
+
+	payloadB64 := base64.StdEncoding.EncodeToString(payload)
+	reply, err := redigo.String(conn.Do("XADD", stream, "*",
+		"topic", topic,
+		"payload", payloadB64,
+		"ts", ts,
+	))
+	if err != nil {
+		return "", fmt.Errorf("XADD failed: %w", err)
+	}
+	return reply, nil
+}
+
+func (r *RedisStream) Read(ctx context.Context, streamName string, startID string, blockMs int) ([]Entry, error) {
+	pool, err := redis.GetRedigoPool()
+	if err != nil {
+		return nil, err
+	}
+	conn := pool.Get()
+	defer conn.Close()
+
+	if blockMs < 0 {
+		blockMs = 0
+	}
+
+	args := []interface{}{"STREAMS", streamName, startID}
+	if blockMs > 0 {
+		args = append([]interface{}{"BLOCK", blockMs, "COUNT", 100}, args...)
+	} else {
+		args = append([]interface{}{"COUNT", 100}, args...)
+	}
+
+	reply, err := conn.Do("XREAD", args...)
+	if err != nil {
+		return nil, err
+	}
+	if reply == nil {
+		return nil, nil
+	}
+
+	return parseXReadReply(reply, streamName)
+}
+
+func (r *RedisStream) Len(ctx context.Context, stream string) (int, error) {
+	pool, err := redis.GetRedigoPool()
+	if err != nil {
+		return 0, err
+	}
+	conn := pool.Get()
+	defer conn.Close()
+
+	return redigo.Int(conn.Do("XLEN", stream))
+}
+
+func (r *RedisStream) Range(ctx context.Context, stream string, startID, endID string) ([]Entry, error) {
+	pool, err := redis.GetRedigoPool()
+	if err != nil {
+		return nil, err
+	}
+	conn := pool.Get()
+	defer conn.Close()
+
+	reply, err := redigo.Values(conn.Do("XRANGE", stream, startID, endID))
+	if err != nil {
+		return nil, err
+	}
+	return parseRangeReply(reply)
+}
+
+func (r *RedisStream) Trim(ctx context.Context, stream string, maxAge time.Duration) (int, error) {
+	pool, err := redis.GetRedigoPool()
+	if err != nil {
+		return 0, err
+	}
+	conn := pool.Get()
+	defer conn.Close()
+
+	cutoff := time.Now().Add(-maxAge)
+	minID := fmt.Sprintf("%d-0", cutoff.UnixMilli())
+
+	// XTRIM MINID requires Redis 6.2+; fall back to XDEL for older Redis
+	n, err := redigo.Int(conn.Do("XTRIM", stream, "MINID", minID))
+	if err == nil {
+		return n, nil
+	}
+
+	// Fallback: XRANGE + XDEL
+	reply, err := redigo.Values(conn.Do("XRANGE", stream, "-", minID))
+	if err != nil {
+		return 0, err
+	}
+
+	deleted := 0
+	for _, item := range reply {
+		entry, err := redigo.Values(item, nil)
+		if err != nil || len(entry) < 1 {
+			continue
+		}
+		msgID, _ := redigo.String(entry[0], nil)
+		if msgID >= minID {
+			continue
+		}
+		n, e := redigo.Int(conn.Do("XDEL", stream, msgID))
+		if e == nil {
+			deleted += n
+		}
+	}
+	return deleted, nil
+}
+
+func parseXReadReply(reply interface{}, streamName string) ([]Entry, error) {
+	top, err := redigo.Values(reply, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []Entry
+	for _, item := range top {
+		streamBlock, err := redigo.Values(item, nil)
+		if err != nil || len(streamBlock) != 2 {
+			continue
+		}
+
+		name, _ := redigo.String(streamBlock[0], nil)
+		if name != streamName {
+			continue
+		}
+
+		msgs, err := redigo.Values(streamBlock[1], nil)
+		if err != nil {
+			continue
+		}
+
+		for _, m := range msgs {
+			ent, err := parseStreamEntry(m)
+			if err != nil {
+				continue
+			}
+			result = append(result, ent)
+		}
+	}
+	return result, nil
+}
+
+func parseRangeReply(reply []interface{}) ([]Entry, error) {
+	var result []Entry
+	for _, item := range reply {
+		ent, err := parseStreamEntry(item)
+		if err != nil {
+			continue
+		}
+		result = append(result, ent)
+	}
+	return result, nil
+}
+
+func parseStreamEntry(item interface{}) (Entry, error) {
+	msg, err := redigo.Values(item, nil)
+	if err != nil || len(msg) != 2 {
+		return Entry{}, fmt.Errorf("invalid entry")
+	}
+
+	msgID, _ := redigo.String(msg[0], nil)
+	fields, err := redigo.StringMap(msg[1], nil)
+	if err != nil {
+		return Entry{}, err
+	}
+
+	topic := fields["topic"]
+	payloadB64 := fields["payload"]
+	ts := int64(0)
+	if t, ok := fields["ts"]; ok && t != "" {
+		ts, _ = strconv.ParseInt(t, 10, 64)
+	}
+
+	payload := []byte{}
+	if payloadB64 != "" {
+		payload, _ = base64.StdEncoding.DecodeString(payloadB64)
+	}
+
+	return Entry{
+		ID:        msgID,
+		Topic:     topic,
+		Payload:   payload,
+		Timestamp: ts,
+	}, nil
+}

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -1,0 +1,35 @@
+package stream
+
+import (
+	"context"
+	"time"
+)
+
+// Entry represents a message in the stream.
+type Entry struct {
+	ID        string
+	Topic     string
+	Payload   []byte
+	Timestamp int64
+}
+
+// Stream abstracts a message stream backend (Redis, Kafka, etc.).
+// Implementations can be swapped without changing callers.
+type Stream interface {
+	// Publish adds a message to the stream. Returns the message ID.
+	Publish(ctx context.Context, stream string, topic string, payload []byte, ts int64) (string, error)
+
+	// Read reads messages from the stream. startID="$" means only new messages.
+	// blockMs: block up to this many ms waiting for data; 0 = non-blocking.
+	// Returns entries (may be empty on timeout) and nil error.
+	Read(ctx context.Context, stream string, startID string, blockMs int) ([]Entry, error)
+
+	// Trim removes entries older than maxAge. Returns the number of entries deleted.
+	Trim(ctx context.Context, stream string, maxAge time.Duration) (int, error)
+
+	// Len returns the number of entries in the stream.
+	Len(ctx context.Context, stream string) (int, error)
+
+	// Range returns entries with ID in [startID, endID]. Use "-" and "+" for min/max.
+	Range(ctx context.Context, stream string, startID, endID string) ([]Entry, error)
+}


### PR DESCRIPTION
- Add stream package: Stream interface + Redis implementation (Publish, Read, Trim, Len, Range)
- Add ele-redis-stream CLI: consume, produce, trim subcommands for room_events
- Trim supports max-age (1h, 30m, 10s), dry-run, XDEL fallback for Redis < 6.2
- Add README with usage and config examples

Made-with: Cursor