### PR TITLE
fix: stabilize tournament SSE snapshot flow and round participant metrics

### DIFF
--- a/lobby_server/worker/tournament/coordinator.go
+++ b/lobby_server/worker/tournament/coordinator.go
@@ -93,6 +93,26 @@ func (tc *coordinator) loop() {
 func (tc *coordinator) tick() {
 	now := time.Now().UTC()
 
+	if err := tc.fillRegistrationOpenTournamentsWithBots(now); err != nil {
+		log.Errorw("tournament: fill bots before begin failed", "err", err)
+	}
+
+	//1. 之前的比赛待匹配players
+	// Grace window: if scheduler runs a little late (e.g. process restart at +1s), still begin this slot.
+	tournamentToBegin, err := db.TournamentGetLatestRegistrationOpenWithinStartGrace(now, 10*time.Second)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Debugw("tournament: no tournament to begin in grace window", "now", now)
+		} else {
+			log.Errorw("tournament: get latest tournament to begin", "err", err)
+		}
+	} else {
+		if err := tc.beginTournament(tournamentToBegin); err != nil {
+			log.Errorw("tournament: begin", "tournament_id", tournamentToBegin.ID, "err", err)
+		}
+	}
+
+	//2. 创建下一个tournament
 	if tc.tournamentCreationEnabled.Load() {
 		if err := tc.ensureNextTournaments(now); err != nil {
 			log.Errorw("tournament: ensure next tournaments", "err", err)
@@ -102,24 +122,6 @@ func (tc *coordinator) tick() {
 		tc.logTournamentCreationDisabled(now)
 	}
 
-	if err := tc.fillRegistrationOpenTournamentsWithBots(now); err != nil {
-		log.Errorw("tournament: fill bots before begin failed", "err", err)
-	}
-
-	//2. 待匹配players
-	// Grace window: if scheduler runs a little late (e.g. process restart at +1s), still begin this slot.
-	tournamentToBegin, err := db.TournamentGetLatestRegistrationOpenWithinStartGrace(now, 10*time.Second)
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			//log.Debugw("tournament: no tournament to begin in grace window", "now", now)
-			return
-		}
-		log.Errorw("tournament: get latest tournament to begin", "err", err)
-		return
-	}
-	if err := tc.beginTournament(tournamentToBegin); err != nil {
-		log.Errorw("tournament: begin", "tournament_id", tournamentToBegin.ID, "err", err)
-	}
 }
 
 func (tc *coordinator) setTournamentCreationEnabled(enabled bool) {

--- a/lobby_server/worker/tournament/coordinator.go
+++ b/lobby_server/worker/tournament/coordinator.go
@@ -101,9 +101,12 @@ func (tc *coordinator) tick() {
 	// Grace window: if scheduler runs a little late (e.g. process restart at +1s), still begin this slot.
 	tournamentToBegin, err := db.TournamentGetLatestRegistrationOpenWithinStartGrace(now, 10*time.Second)
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			log.Debugw("tournament: no tournament to begin in grace window", "now", now)
-		} else {
+		//if errors.Is(err, gorm.ErrRecordNotFound) {
+		//	log.Debugw("tournament: no tournament to begin in grace window", "now", now)
+		//} else {
+		//	log.Errorw("tournament: get latest tournament to begin", "err", err)
+		//}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			log.Errorw("tournament: get latest tournament to begin", "err", err)
 		}
 	} else {

--- a/server/api/subscribe_game_info.go
+++ b/server/api/subscribe_game_info.go
@@ -307,11 +307,11 @@ func (task *SubscribeGameInfoTask) Run(c *gin.Context) (Response, error) {
 				log.Errorf("failed to check if player is in tournament: %v", err)
 				continue
 			}
-			if playerInTournament {
-				continue // 如果玩家在上一场进行的tournament中，则不发送tournament snapshot
-			}
 			if msg.GetTopic() == pubsub.TopicTournamentRoster && msg.GetEvent() != nil &&
 				msg.GetEvent().GetType() == proto.EventType_TYPE_TOURNAMENT_ROSTER_UPDATE {
+				if playerInTournament {
+					continue // 如果玩家在上一场进行的tournament中，则不发送tournament snapshot
+				}
 				if err := task.sendTournamentSnapshotSSE(c, self, lobbyClient, msg.GetMessageId()); err != nil {
 					log.Errorf("send tournament snapshot from roster update failed: %v", err)
 				}

--- a/server/api/subscribe_game_info.go
+++ b/server/api/subscribe_game_info.go
@@ -1005,10 +1005,15 @@ func readRoundConfigFromTierTable(participantCount int64) (map[int32]*proto.Tour
 	}
 	out := make(map[int32]*proto.TournamentRoundConfig, len(rows))
 	for _, row := range rows {
-		remainingParticipantCount := row.TotalPlayerCount >> row.TierNo
+		remainingParticipantCount := row.TotalPlayerCount //当前round剩余玩家数
+		if row.TierNo > 1 {
+			remainingParticipantCount = row.TotalPlayerCount >> (row.TierNo - 1)
+		}
 		if remainingParticipantCount < 1 {
+			log.Errorf("remaining participant count is less than 1: %d", remainingParticipantCount)
 			remainingParticipantCount = 1
 		}
+
 		out[row.TierNo] = &proto.TournamentRoundConfig{
 			TotalPlayerCount:          row.TotalPlayerCount,
 			TokenChange:               row.RewardToken,

--- a/server/api/subscribe_game_info.go
+++ b/server/api/subscribe_game_info.go
@@ -302,24 +302,27 @@ func (task *SubscribeGameInfoTask) Run(c *gin.Context) (Response, error) {
 				log.Infof("event stream closed - RequestUUID: %s", task.Request.RequestUUID)
 				return task.Response, nil
 			}
-			playerInTournament, err := db.TournamentPlayerInActiveBracket(self.Id, self.TemporaryAddress)
-			if err != nil {
-				log.Errorf("failed to check if player is in tournament: %v", err)
-				continue
-			}
-			if msg.GetTopic() == pubsub.TopicTournamentRoster && msg.GetEvent() != nil &&
-				msg.GetEvent().GetType() == proto.EventType_TYPE_TOURNAMENT_ROSTER_UPDATE {
-				if playerInTournament {
-					continue // 如果玩家在上一场进行的tournament中，则不发送tournament snapshot
+
+			if msg.GetTopic() == pubsub.TopicTournamentRoster {
+				playerInTournament, err := db.TournamentPlayerInActiveBracket(self.Id, self.TemporaryAddress)
+				if err != nil {
+					log.Errorf("failed to check if player is in tournament: %v", err)
+					continue
 				}
-				if err := task.sendTournamentSnapshotSSE(c, self, lobbyClient, msg.GetMessageId()); err != nil {
-					log.Errorf("send tournament snapshot from roster update failed: %v", err)
+				if msg.GetEvent() != nil &&
+					msg.GetEvent().GetType() == proto.EventType_TYPE_TOURNAMENT_ROSTER_UPDATE {
+					if playerInTournament {
+						continue // 如果玩家在上一场进行的tournament中，则不发送tournament snapshot
+					}
+					if err := task.sendTournamentSnapshotSSE(c, self, lobbyClient, msg.GetMessageId()); err != nil {
+						log.Errorf("send tournament snapshot from roster update failed: %v", err)
+					}
 				}
-				continue
-			}
-			sseEvent := task.convertRoomServerEventToSSE(msg, task.Request.RequestUUID)
-			if err := sendSSEEvent(c.Writer, c.Writer.(http.Flusher), sseEvent); err != nil {
-				log.Errorf("failed to send SSE event: %v", err)
+			} else {
+				sseEvent := task.convertRoomServerEventToSSE(msg, task.Request.RequestUUID)
+				if err := sendSSEEvent(c.Writer, c.Writer.(http.Flusher), sseEvent); err != nil {
+					log.Errorf("failed to send SSE event: %v", err)
+				}
 			}
 		case err, ok := <-errCh:
 			if !ok {

--- a/server/api/subscribe_game_info.go
+++ b/server/api/subscribe_game_info.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/CryptoElementals/common/config"
 	"github.com/CryptoElementals/common/db"
 	"github.com/CryptoElementals/common/log"
 	dao "github.com/CryptoElementals/common/models"
@@ -24,6 +26,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/mitchellh/mapstructure"
 	"google.golang.org/protobuf/encoding/protojson"
+	"gorm.io/gorm"
 )
 
 func init() {
@@ -298,6 +301,14 @@ func (task *SubscribeGameInfoTask) Run(c *gin.Context) (Response, error) {
 			if !ok {
 				log.Infof("event stream closed - RequestUUID: %s", task.Request.RequestUUID)
 				return task.Response, nil
+			}
+			playerInTournament, err := db.TournamentPlayerInActiveBracket(self.Id, self.TemporaryAddress)
+			if err != nil {
+				log.Errorf("failed to check if player is in tournament: %v", err)
+				continue
+			}
+			if playerInTournament {
+				continue // 如果玩家在上一场进行的tournament中，则不发送tournament snapshot
 			}
 			if msg.GetTopic() == pubsub.TopicTournamentRoster && msg.GetEvent() != nil &&
 				msg.GetEvent().GetType() == proto.EventType_TYPE_TOURNAMENT_ROSTER_UPDATE {
@@ -807,19 +818,40 @@ func (task *SubscribeGameInfoTask) sendTournamentSnapshotSSE(c *gin.Context, sel
 	if err != nil {
 		return fmt.Errorf("TournamentPlayerInActiveBracket: %w", err)
 	}
+
+	var snapResp *proto.GetLatestRegistrationOpenTournamentSnapshotResponse
 	if busy {
-		return nil
+		now := time.Now().UTC()
+		inProgress, inProgressErr := db.TournamentGetLatestInProgress()
+		if inProgressErr != nil {
+			if inProgressErr == gorm.ErrRecordNotFound {
+				return nil
+			}
+			return fmt.Errorf("TournamentGetLatestInProgress: %w", inProgressErr)
+		}
+		// When player is still tied to an already-running tournament, push that snapshot
+		// so reconnect clients keep context of the current event instead of next registration-open.
+		snapResp, err = buildTournamentSnapshotResponse(inProgress, self, now)
+		if err != nil {
+			return fmt.Errorf("build in-progress tournament snapshot: %w", err)
+		}
+	} else {
+		ctx := c.Request.Context()
+		latestResp, snapErr := lobbyClient.GetLatestRegistrationOpenTournamentSnapshot(ctx, self)
+		if snapErr != nil {
+			return fmt.Errorf("lobby GetLatestRegistrationOpenTournamentSnapshot failed: %w", snapErr)
+		}
+		if latestResp == nil || !latestResp.GetHasTournament() {
+			return nil
+		}
+		// For non-busy players, keep existing behavior: only show latest registration-open snapshot.
+		if latestResp.GetTournamentStatus() != string(dao.TournamentStatusRegistrationOpen) {
+			return nil
+		}
+		snapResp = latestResp
 	}
-	ctx := c.Request.Context()
-	snapResp, snapErr := lobbyClient.GetLatestRegistrationOpenTournamentSnapshot(ctx, self)
-	if snapErr != nil {
-		return fmt.Errorf("lobby GetLatestRegistrationOpenTournamentSnapshot failed: %w", snapErr)
-	}
+
 	if snapResp == nil || !snapResp.GetHasTournament() {
-		return nil
-	}
-	// Subscribe API only pushes not-started tournaments (registration open).
-	if snapResp.GetTournamentStatus() != string(dao.TournamentStatusRegistrationOpen) {
 		return nil
 	}
 	if sourceMessageID == "" {
@@ -859,6 +891,137 @@ func (task *SubscribeGameInfoTask) sendTournamentSnapshotSSE(c *gin.Context, sel
 		return fmt.Errorf("sendSSEEvent tournament snapshot: %w", err)
 	}
 	return nil
+}
+
+func buildTournamentSnapshotResponse(t *dao.Tournament, self *proto.PlayerAddress, now time.Time) (*proto.GetLatestRegistrationOpenTournamentSnapshotResponse, error) {
+	if t == nil || self == nil {
+		return nil, fmt.Errorf("invalid snapshot build args")
+	}
+	count, err := db.TournamentCountParticipantsForPool(t.TournamentID)
+	if err != nil {
+		return nil, fmt.Errorf("participant count: %w", err)
+	}
+
+	entryFee := t.EntryFee
+	pool := int64(entryFee) * count
+
+	var playerReg bool
+	var partStatus string
+	p, perr := db.TournamentGetParticipantByPlayer(t.TournamentID, self.Id, self.TemporaryAddress)
+	if perr == nil {
+		playerReg = true
+		partStatus = string(p.Status)
+	} else if !errors.Is(perr, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("participant lookup: %w", perr)
+	}
+
+	secs := int64(t.ScheduledStartAt.Sub(now).Seconds())
+	if secs < 0 {
+		secs = 0
+	}
+	topFourRewardTokens, err := topFourRewardTokensFromTierTable(count)
+	if err != nil {
+		return nil, fmt.Errorf("tier reward config: %w", err)
+	}
+	mapRoundConfig, err := readRoundConfigFromTierTable(count)
+	if err != nil {
+		return nil, fmt.Errorf("round config: %w", err)
+	}
+	mapRoundConfigProto := mapRoundConfig
+	return &proto.GetLatestRegistrationOpenTournamentSnapshotResponse{
+		HasTournament:               true,
+		TournamentID:                t.TournamentID,
+		TournamentStatus:            string(t.Status),
+		ScheduledStartUnixSec:       t.ScheduledStartAt.Unix(),
+		RegistrationDeadlineUnixSec: t.RegistrationDeadline.Unix(),
+		EntryFee:                    entryFee,
+		ParticipantCount:            count,
+		PlayerRegistered:            playerReg,
+		PlayerParticipantStatus:     partStatus,
+		TopFourRewardTokens:         topFourRewardTokens,
+		PrizePoolTokens:             pool,
+		SecondsUntilScheduledStart:  secs,
+		MinPlayersRequired:          minPlayersRequiredFromConfig(),
+		MapRoundConfig:              mapRoundConfigProto,
+	}, nil
+}
+
+func tournamentTierBracketSize(participantCount int64) int32 {
+	switch {
+	case participantCount < 128:
+		return 64
+	case participantCount < 256:
+		return 128
+	case participantCount < 512:
+		return 256
+	case participantCount < 1024:
+		return 512
+	case participantCount < 2048:
+		return 1024
+	case participantCount < 4096:
+		return 2048
+	case participantCount < 8192:
+		return 4096
+	default:
+		return 8192
+	}
+}
+
+func topFourRewardTokensFromTierTable(participantCount int64) ([]int32, error) {
+	totalPlayerCount := tournamentTierBracketSize(participantCount)
+
+	var rows []dao.TournamentTierRewardConfig
+	if err := db.Get().
+		Where("total_player_count = ?", totalPlayerCount).
+		Order("tier_no desc").
+		Limit(3).
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	// [highest, second-highest, second-highest, third-highest]
+	out := make([]int32, 4)
+	if len(rows) > 0 {
+		out[0] = rows[0].RewardToken
+	}
+	if len(rows) > 1 {
+		out[1] = rows[1].RewardToken
+		out[2] = rows[1].RewardToken
+	}
+	if len(rows) > 2 {
+		out[3] = rows[2].RewardToken
+	}
+	return out, nil
+}
+
+func readRoundConfigFromTierTable(participantCount int64) (map[int32]*proto.TournamentRoundConfig, error) {
+	totalPlayerCount := tournamentTierBracketSize(participantCount)
+	rows, err := db.TournamentTierRewardConfigListByBracketSize(totalPlayerCount)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[int32]*proto.TournamentRoundConfig, len(rows))
+	for _, row := range rows {
+		remainingParticipantCount := row.TotalPlayerCount >> row.TierNo
+		if remainingParticipantCount < 1 {
+			remainingParticipantCount = 1
+		}
+		out[row.TierNo] = &proto.TournamentRoundConfig{
+			TotalPlayerCount:          row.TotalPlayerCount,
+			TokenChange:               row.RewardToken,
+			PointChange:               row.Point,
+			RemainingParticipantCount: remainingParticipantCount,
+		}
+	}
+	return out, nil
+}
+
+func minPlayersRequiredFromConfig() int32 {
+	v := int32(config.LSGConf.TournamentCfg.MinPlayersRequired)
+	if v <= 0 {
+		return 64
+	}
+	return v
 }
 
 // sendSSEEvent 发送 SSE 事件


### PR DESCRIPTION
## Summary
- send in-progress tournament snapshots for players who are currently in an active bracket
- only apply tournament roster-specific checks on roster update events, so non-roster SSE events continue to flow normally
- correct per-round remaining participant count calculation (e.g. first round shows full participants, later rounds halve by tier)
- keep tournament scheduler creating the next slot even when begin-window checks return no record
- reduce noisy logging by only reporting real errors (non-not-found) in begin-window lookup paths