### PR TITLE
feat: add predictive pre-deadline bot fill for tournaments

### DIFF
--- a/config/lobbyserver_config.go
+++ b/config/lobbyserver_config.go
@@ -27,12 +27,14 @@ type LobbyServerConfig struct {
 }
 
 type TournamentConfig struct {
-	EntryFee           int32   `mapstructure:"entry-fee"`
-	MinPlayersRequired uint32  `mapstructure:"min-players-required"`
-	IntervalSeconds    uint32  `mapstructure:"interval-seconds"`
-	BeforeStartSeconds uint32  `mapstructure:"before-start-seconds"`
+	EntryFee                int32   `mapstructure:"entry-fee"`
+	MinPlayersRequired      uint32  `mapstructure:"min-players-required"`
+	IntervalSeconds         uint32  `mapstructure:"interval-seconds"`
+	BeforeStartSeconds      uint32  `mapstructure:"before-start-seconds"`
+	BotFillWindowSeconds    uint32  `mapstructure:"bot-fill-window-seconds"`
+	BotFillIntervalSeconds  uint32  `mapstructure:"bot-fill-interval-seconds"`
 	// TopFourPrizeTokens is rank 1..4 fixed prize amounts (tokens) shown to clients; pool is entry_fee * participants.
-	TopFourPrizeTokens []int32 `mapstructure:"top-four-prize-tokens"`
+	TopFourPrizeTokens       []int32 `mapstructure:"top-four-prize-tokens"`
 }
 
 // InitLSConfig loads lobby server config from a YAML file (viper).
@@ -49,6 +51,12 @@ func InitLSConfig(configPath string) error {
 	}
 	if LSGConf.BotRegistryFreshnessSec <= 0 {
 		LSGConf.BotRegistryFreshnessSec = 10
+	}
+	if LSGConf.TournamentCfg.BotFillWindowSeconds == 0 {
+		LSGConf.TournamentCfg.BotFillWindowSeconds = 180
+	}
+	if LSGConf.TournamentCfg.BotFillIntervalSeconds == 0 {
+		LSGConf.TournamentCfg.BotFillIntervalSeconds = 15
 	}
 	return nil
 }

--- a/db/tournament.go
+++ b/db/tournament.go
@@ -184,6 +184,21 @@ func TournamentListRegistrationOpenReachedDeadline(now time.Time) ([]dao.Tournam
 	return rows, err
 }
 
+// TournamentListRegistrationOpenInBotFillWindow lists registration_open tournaments whose registration deadline
+// is within [now, now+window], used for progressive bot fill before deadline.
+func TournamentListRegistrationOpenInBotFillWindow(now time.Time, window time.Duration) ([]dao.Tournament, error) {
+	if window <= 0 {
+		return []dao.Tournament{}, nil
+	}
+	var rows []dao.Tournament
+	end := now.Add(window)
+	err := Get().
+		Where("status = ? AND registration_deadline >= ? AND registration_deadline <= ?", dao.TournamentStatusRegistrationOpen, now, end).
+		Order("registration_deadline ASC, id ASC").
+		Find(&rows).Error
+	return rows, err
+}
+
 // TournamentGetLatestRegistrationOpenWithinStartGrace returns one latest registration_open tournament
 // whose scheduled_start_at is within [now-grace, now]. This allows small scheduler/restart delays.
 func TournamentGetLatestRegistrationOpenWithinStartGrace(now time.Time, grace time.Duration) (*dao.Tournament, error) {

--- a/lobby_server/server.go
+++ b/lobby_server/server.go
@@ -89,6 +89,8 @@ func New(ctx context.Context, cfg *config.LobbyServerConfig) (*Service, error) {
 		cfg.TournamentCfg.MinPlayersRequired,
 		cfg.TournamentCfg.IntervalSeconds,
 		cfg.TournamentCfg.BeforeStartSeconds,
+		cfg.TournamentCfg.BotFillWindowSeconds,
+		cfg.TournamentCfg.BotFillIntervalSeconds,
 		cfg.BotRegistryFreshnessSec,
 	)
 	s.grpcHandlers = NewGRPCServices(s.queueSvc, s.tournamentSvc, rw)

--- a/lobby_server/worker/tournament/coordinator.go
+++ b/lobby_server/worker/tournament/coordinator.go
@@ -8,6 +8,7 @@ import (
 	"math/bits"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -43,12 +44,15 @@ type coordinator struct {
 	beforeStartSeconds uint32
 
 	botFreshness time.Duration
+	botFillWindow time.Duration
+	botFillInterval time.Duration
+	botFillLastJoinByTournament sync.Map // map[tournamentID]unixMilli
 
 	tournamentCreationEnabled atomic.Bool
 	lastDisabledLogUnixSec    atomic.Int64
 }
 
-func newCoordinator(parent context.Context, publisher pubsub.Publisher, botStore *bot_manager.RedisStore, gameCreator GameCreator, entryFee int32, minPlayersRequired uint32, intervalSeconds uint32, beforeStartSeconds uint32, botFreshnessSec int64) *coordinator {
+func newCoordinator(parent context.Context, publisher pubsub.Publisher, botStore *bot_manager.RedisStore, gameCreator GameCreator, entryFee int32, minPlayersRequired uint32, intervalSeconds uint32, beforeStartSeconds uint32, botFillWindowSeconds uint32, botFillIntervalSeconds uint32, botFreshnessSec int64) *coordinator {
 	ctx, cancel := context.WithCancel(parent)
 	tc := &coordinator{
 		ctx:                ctx,
@@ -61,6 +65,8 @@ func newCoordinator(parent context.Context, publisher pubsub.Publisher, botStore
 		intervalSeconds:    intervalSeconds,
 		beforeStartSeconds: beforeStartSeconds,
 		botFreshness:       time.Duration(botFreshnessSec) * time.Second,
+		botFillWindow:      time.Duration(botFillWindowSeconds) * time.Second,
+		botFillInterval:    time.Duration(botFillIntervalSeconds) * time.Second,
 	}
 	tc.tournamentCreationEnabled.Store(true)
 	return tc
@@ -154,7 +160,10 @@ func (tc *coordinator) fillRegistrationOpenTournamentsWithBots(now time.Time) er
 	if tc.botStore == nil {
 		return nil
 	}
-	rows, err := db.TournamentListRegistrationOpenReachedDeadline(now)
+	if tc.botFillWindow <= 0 || tc.botFillInterval <= 0 {
+		return nil
+	}
+	rows, err := db.TournamentListRegistrationOpenInBotFillWindow(now, tc.botFillWindow)
 	if err != nil {
 		return err
 	}
@@ -171,6 +180,7 @@ func (tc *coordinator) fillTournamentWithBotsIfNeeded(now time.Time, tournamentI
 		return nil
 	}
 	need := 0
+	var remainingToDeadline time.Duration
 	err := db.Get().Transaction(func(tx *gorm.DB) error {
 		var t dao.Tournament
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
@@ -179,9 +189,12 @@ func (tc *coordinator) fillTournamentWithBotsIfNeeded(now time.Time, tournamentI
 			return err
 		}
 		if t.Status != dao.TournamentStatusRegistrationOpen {
+			tc.botFillLastJoinByTournament.Delete(tournamentID)
 			return nil
 		}
-		if now.Before(t.RegistrationDeadline) {
+		fillStart := t.RegistrationDeadline.Add(-tc.botFillWindow)
+		if now.Before(fillStart) || !now.Before(t.RegistrationDeadline) {
+			tc.botFillLastJoinByTournament.Delete(tournamentID)
 			return nil
 		}
 		queued, err := db.TournamentListParticipantsByStatus(tx, t.TournamentID, dao.TournamentParticipantStatusQueued)
@@ -193,9 +206,11 @@ func (tc *coordinator) fillTournamentWithBotsIfNeeded(now time.Time, tournamentI
 			target++
 		}
 		if len(queued) >= target {
+			tc.botFillLastJoinByTournament.Delete(tournamentID)
 			return nil
 		}
 		need = target - len(queued)
+		remainingToDeadline = t.RegistrationDeadline.Sub(now)
 		return nil
 	})
 	if err != nil {
@@ -207,32 +222,84 @@ func (tc *coordinator) fillTournamentWithBotsIfNeeded(now time.Time, tournamentI
 	if need <= 0 {
 		return nil
 	}
-
-	for i := 0; i < need; i++ {
-		bot, err := tc.botStore.PopFreshIdleBotForMatch(now.UnixMilli(), tc.botFreshness.Milliseconds())
-		if err != nil {
-			return err
-		}
-		if bot == nil {
-			return nil
-		}
-		if tc.joinTournamentFunc == nil {
-			return fmt.Errorf("nil tournament join function")
-		}
-		if err := tc.joinTournamentFunc(tournamentID, &proto.PlayerAddress{
-			Id:               bot.Id,
-			TemporaryAddress: bot.TemporaryAddress,
-		}); err != nil {
-			_, rerr := tc.botStore.ReleaseInGameBot(*bot, now.UnixMilli(), tc.botFreshness.Milliseconds())
-			if rerr != nil {
-				log.Warnw("tournament: release bot after failed join failed", "bot", bot.String(), "err", rerr)
-			}
-			log.Warnw("tournament: bot join tournament failed", "tournament_id", tournamentID, "bot", bot.String(), "err", err)
-			continue
-		}
-		log.Debugw("tournament: bot join tournament success", "tournament_id", tournamentID, "bot", bot.String())
+	effectiveInterval := tc.predictiveBotFillInterval(need, remainingToDeadline)
+	if !tc.shouldAddBotNow(tournamentID, now, effectiveInterval) {
+		return nil
 	}
+
+	bot, err := tc.botStore.PopFreshIdleBotForMatch(now.UnixMilli(), tc.botFreshness.Milliseconds())
+	if err != nil {
+		return err
+	}
+	if bot == nil {
+		return nil
+	}
+	if tc.joinTournamentFunc == nil {
+		return fmt.Errorf("nil tournament join function")
+	}
+	if err := tc.joinTournamentFunc(tournamentID, &proto.PlayerAddress{
+		Id:               bot.Id,
+		TemporaryAddress: bot.TemporaryAddress,
+	}); err != nil {
+		_, rerr := tc.botStore.ReleaseInGameBot(*bot, now.UnixMilli(), tc.botFreshness.Milliseconds())
+		if rerr != nil {
+			log.Warnw("tournament: release bot after failed join failed", "bot", bot.String(), "err", rerr)
+		}
+		log.Warnw("tournament: bot join tournament failed", "tournament_id", tournamentID, "bot", bot.String(), "err", err)
+		return nil
+	}
+	log.Debugw("tournament: bot join tournament success",
+		"tournament_id", tournamentID,
+		"bot", bot.String(),
+		"need_before_join", need,
+		"remaining_to_deadline_ms", remainingToDeadline.Milliseconds(),
+		"effective_interval_ms", effectiveInterval.Milliseconds())
 	return nil
+}
+
+func (tc *coordinator) shouldAddBotNow(tournamentID string, now time.Time, interval time.Duration) bool {
+	if interval <= 0 {
+		interval = time.Second
+	}
+	nowMs := now.UnixMilli()
+	if v, ok := tc.botFillLastJoinByTournament.Load(tournamentID); ok {
+		lastMs, _ := v.(int64)
+		if nowMs-lastMs < interval.Milliseconds() {
+			return false
+		}
+	}
+	tc.botFillLastJoinByTournament.Store(tournamentID, nowMs)
+	return true
+}
+
+// predictiveBotFillInterval computes a faster cadence when the current shortage
+// cannot be covered in time with the base interval.
+func (tc *coordinator) predictiveBotFillInterval(need int, remainingToDeadline time.Duration) time.Duration {
+	base := tc.botFillInterval
+	if base <= 0 {
+		base = time.Second
+	}
+	if need <= 0 || remainingToDeadline <= 0 {
+		return base
+	}
+	// Last-slot protection: when only 1 seat is missing and deadline is very near,
+	// tighten cadence to tick interval so we don't miss the final fill chance.
+	if need == 1 && remainingToDeadline < 5*time.Second {
+		if tickInterval < base {
+			return tickInterval
+		}
+		return base
+	}
+
+	// Average pace needed to fill all missing slots before deadline.
+	target := remainingToDeadline / time.Duration(need)
+	if target < time.Second {
+		target = time.Second
+	}
+	if target < base {
+		return target
+	}
+	return base
 }
 
 func (tc *coordinator) ensureNextTournaments(now time.Time) error {

--- a/lobby_server/worker/tournament/service.go
+++ b/lobby_server/worker/tournament/service.go
@@ -25,10 +25,10 @@ type TournamentQueueService struct {
 }
 
 // NewTournamentQueueService constructs the tournament worker. Call Start after DB is ready.
-func NewTournamentQueueService(ctx context.Context, publisher pubsub.Publisher, botStore *bot_manager.RedisStore, gameCreator GameCreator, entryFee int32, minPlayersRequired uint32, intervalSeconds uint32, beforeStartSeconds uint32, botFreshnessSec int64) *TournamentQueueService {
+func NewTournamentQueueService(ctx context.Context, publisher pubsub.Publisher, botStore *bot_manager.RedisStore, gameCreator GameCreator, entryFee int32, minPlayersRequired uint32, intervalSeconds uint32, beforeStartSeconds uint32, botFillWindowSeconds uint32, botFillIntervalSeconds uint32, botFreshnessSec int64) *TournamentQueueService {
 	svc := &TournamentQueueService{
 		ctx:   ctx,
-		coord: newCoordinator(ctx, publisher, botStore, gameCreator, entryFee, minPlayersRequired, intervalSeconds, beforeStartSeconds, botFreshnessSec),
+		coord: newCoordinator(ctx, publisher, botStore, gameCreator, entryFee, minPlayersRequired, intervalSeconds, beforeStartSeconds, botFillWindowSeconds, botFillIntervalSeconds, botFreshnessSec),
 	}
 	svc.coord.joinTournamentFunc = func(tournamentID string, req *proto.PlayerAddress) error {
 		return svc.handleJoinTournamentEvent(tournamentID, req, true)

--- a/lobby_server/worker/tournament/tournament_test.go
+++ b/lobby_server/worker/tournament/tournament_test.go
@@ -61,7 +61,7 @@ func TestHandleJoinTournamentEvent_Success(t *testing.T) {
 	seedProfileAndToken(t, 5001, "p5001", 5000)
 	seedTournament(t, "tour-success", time.Now().Add(10*time.Minute))
 
-	svc := NewTournamentQueueService(context.Background(), noopPublisher{}, nil, &noopGameCreator{}, 1000, 2, 3600, 180, 10)
+	svc := NewTournamentQueueService(context.Background(), noopPublisher{}, nil, &noopGameCreator{}, 1000, 2, 3600, 180, 180, 15, 10)
 	req := &proto.PlayerAddress{Id: 5001, TemporaryAddress: " 0xABCDEF "}
 	require.NoError(t, svc.HandleJoinTournamentEvent("tour-success", req))
 
@@ -87,7 +87,7 @@ func TestHandleJoinTournamentEvent_DuplicateJoinRejected(t *testing.T) {
 	seedProfileAndToken(t, 5002, "p5002", 5000)
 	seedTournament(t, "tour-dup", time.Now().Add(10*time.Minute))
 
-	svc := NewTournamentQueueService(context.Background(), noopPublisher{}, nil, &noopGameCreator{}, 1000, 2, 3600, 180, 10)
+	svc := NewTournamentQueueService(context.Background(), noopPublisher{}, nil, &noopGameCreator{}, 1000, 2, 3600, 180, 180, 15, 10)
 	req := &proto.PlayerAddress{Id: 5002, TemporaryAddress: "0xdup"}
 	require.NoError(t, svc.HandleJoinTournamentEvent("tour-dup", req))
 
@@ -107,7 +107,7 @@ func TestHandleJoinTournamentEvent_RejectWhenDeadlineExceeded(t *testing.T) {
 	seedProfileAndToken(t, 5003, "p5003", 5000)
 	seedTournament(t, "tour-expired", time.Now().Add(-1*time.Minute))
 
-	svc := NewTournamentQueueService(context.Background(), noopPublisher{}, nil, &noopGameCreator{}, 1000, 2, 3600, 180, 10)
+	svc := NewTournamentQueueService(context.Background(), noopPublisher{}, nil, &noopGameCreator{}, 1000, 2, 3600, 180, 180, 15, 10)
 	err := svc.HandleJoinTournamentEvent("tour-expired", &proto.PlayerAddress{Id: 5003, TemporaryAddress: "0xlate"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "registration deadline has passed")
@@ -124,7 +124,7 @@ func TestHandleJoinTournamentEvent_RejectWhenTokenNotEnough(t *testing.T) {
 	seedProfileAndToken(t, 5004, "p5004", 500)
 	seedTournament(t, "tour-no-token", time.Now().Add(10*time.Minute))
 
-	svc := NewTournamentQueueService(context.Background(), noopPublisher{}, nil, &noopGameCreator{}, 1000, 2, 3600, 180, 10)
+	svc := NewTournamentQueueService(context.Background(), noopPublisher{}, nil, &noopGameCreator{}, 1000, 2, 3600, 180, 180, 15, 10)
 	err := svc.HandleJoinTournamentEvent("tour-no-token", &proto.PlayerAddress{Id: 5004, TemporaryAddress: "0xpoor"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "user token amount is not enough")


### PR DESCRIPTION
## Summary
- add configurable pre-deadline bot-fill controls for tournaments (`bot-fill-window-seconds` and `bot-fill-interval-seconds`)
- introduce shortage-aware predictive bot fill pacing so joins speed up when remaining time is tight
- keep strict deadline behavior: bot joins are still blocked after `registration_deadline`
- add last-slot protection for near-deadline scenarios to reduce ending at `minPlayersRequired - 1`
- wire new settings through lobby service construction and update tournament worker tests for the new constructor