### PR TITLE
Use asynq process scheduler for lobby bot matchmaking ticks

### DIFF
--- a/db/user_token.go
+++ b/db/user_token.go
@@ -304,18 +304,20 @@ func UnlockUserTokenByGameID(ctx context.Context, gameID int64) error {
 
 // BattleResultSettlement applies PVP economy updates for gr.GameID. gr must be non-nil (caller loads it).
 // Inside the transaction: lock games row, load game_args only (via games.game_args_id), not turns/players.
-func BattleResultSettlement(gr *dao.GameResult) error {
+// When skippedDuplicate is true, economy was already applied (battle_rewards row existed); callers may skip side effects that are not safe to repeat.
+func BattleResultSettlement(gr *dao.GameResult) (skippedDuplicate bool, err error) {
 	if gr == nil {
-		return errors.New("battle result settlement: game result is nil")
+		return false, errors.New("battle result settlement: game result is nil")
 	}
 	gameID := gr.GameID
 	if gameID == 0 {
-		return nil
+		return false, nil
 	}
 	if gr.GameResultType == proto.GameResultType_GAME_ABORTED {
 		log.Debugw("unlock player token caused by abort outcome", "game id", gameID)
-		return UnlockUserTokenByGameID(context.Background(), gameID)
+		return false, UnlockUserTokenByGameID(context.Background(), gameID)
 	}
+	var skipped bool
 	if err := Get().Transaction(func(tx *gorm.DB) error {
 		if err := LockGameForUpdateTx(tx, gameID); err != nil {
 			return err
@@ -334,6 +336,7 @@ func BattleResultSettlement(gr *dao.GameResult) error {
 		}
 		if exists {
 			log.Debugw("battle settlement skipped: battle_rewards row already exists for game", "game_id", gameID)
+			skipped = true
 			return nil
 		}
 		reward, err := EnsureBattleRewardPVPLoadedOrCreated(tx, gameID, gr)
@@ -394,10 +397,10 @@ func BattleResultSettlement(gr *dao.GameResult) error {
 		}
 		return nil
 	}); err != nil {
-		return fmt.Errorf("battle result settlement: game id: %d: %w", gameID, err)
+		return false, fmt.Errorf("battle result settlement: game id: %d: %w", gameID, err)
 	}
 
-	return nil
+	return skipped, nil
 }
 
 func GetPlayerToken(ctx context.Context, playerId int64) (*dao.UserToken, error) {

--- a/lobby_server/room_settlement_subscriber.go
+++ b/lobby_server/room_settlement_subscriber.go
@@ -2,122 +2,181 @@ package lobbyserver
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/CryptoElementals/common/log"
 	"github.com/CryptoElementals/common/pubsub"
 	"github.com/CryptoElementals/common/rpc/proto"
+	"github.com/CryptoElementals/common/stream"
+	goproto "google.golang.org/protobuf/proto"
 )
 
-// runRoomSettlementSubscriber reads [pubsub.TopicRoomSettlementPVP] from Redis (same cluster as room server).
+// Redis consumer group names for multi-lobby settlement (one group per stream key).
+const (
+	settlementGroupPVP        = "lobby_room_settlement_pvp"
+	settlementGroupTournament = "lobby_room_settlement_tournament"
+)
+
+const (
+	settlementReadCount = 32
+	settlementBlockMS   = 1000
+	handlerErrBackoff   = time.Second
+	readErrBackoff      = 500 * time.Millisecond
+	// settlementAutoClaimMinIdleMS is the minimum time a message may sit in another consumer's PEL before XAUTOCLAIM steals it (dead consumer / stuck peer).
+	settlementAutoClaimMinIdleMS = 2_000
+)
+
+// runRoomSettlementSubscriber reads settlement streams via Redis consumer groups so each
+// message is handled by at most one lobby replica (XREADGROUP + XACK).
 func (s *Service) runRoomSettlementSubscriber() {
-	go func() {
-		for {
-			if s.ctx.Err() != nil {
-				return
-			}
-			err := s.readRoomSettlementPVPStream(s.ctx)
-			if s.ctx.Err() != nil {
-				return
-			}
-			if err != nil {
-				log.Warnw("lobby: room settlement stream ended", "err", err)
-			}
-			select {
-			case <-s.ctx.Done():
-				return
-			case <-time.After(2 * time.Second):
-			}
-		}
-	}()
+	consumer := settlementConsumerName()
+	go s.runSettlementStreamLoop(pubsub.TopicRoomSettlementPVP, settlementGroupPVP, consumer, s.grpcHandlers.HandleGameCompletedFromRoom, 2*time.Second)
 
-	go func() {
-		for {
-			if s.ctx.Err() != nil {
-				return
-			}
-			err := s.readRoomSettlementTournamentStream(s.ctx)
-			if s.ctx.Err() != nil {
-				return
-			}
-			if err != nil {
-				log.Warnw("lobby: room settlement tournament stream ended", "err", err)
-			}
-			select {
-			case <-s.ctx.Done():
-				return
-			case <-time.After(1 * time.Second):
-			}
-		}
-	}()
+	go s.runSettlementStreamLoop(pubsub.TopicRoomSettlementTournament, settlementGroupTournament, consumer, s.grpcHandlers.HandleGameCompletedFromTournamentStream, time.Second)
 }
 
-func (s *Service) readRoomSettlementPVPStream(ctx context.Context) error {
-	if s.eventStream == nil {
+func settlementConsumerName() string {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		host = "unknown"
+	}
+	return fmt.Sprintf("%s-%d", host, os.Getpid())
+}
+
+func ensureSettlementConsumerGroup(ctx context.Context, st stream.Stream, streamKey, group string) error {
+	err := st.GroupCreate(ctx, streamKey, group, "0", true)
+	if err == nil {
 		return nil
 	}
-	sub := pubsub.NewStreamSubscriber(s.eventStream)
-	msgCh, stop, err := sub.Subscribe(ctx, pubsub.TopicRoomSettlementPVP, pubsub.SubscribeOptions{})
-	if err != nil {
-		return err
+	if strings.Contains(strings.ToLower(err.Error()), "busygroup") {
+		return nil
 	}
-	defer stop()
+	return fmt.Errorf("xgroup create %s %s: %w", streamKey, group, err)
+}
 
+func (s *Service) runSettlementStreamLoop(streamKey, group, consumer string, handle func(int64) error, restartDelay time.Duration) {
 	for {
+		if s.ctx.Err() != nil {
+			return
+		}
+		if s.eventStream == nil {
+			return
+		}
+		err := ensureSettlementConsumerGroup(s.ctx, s.eventStream, streamKey, group)
+		if err != nil {
+			log.Errorw("lobby: settlement consumer group create failed", "stream", streamKey, "err", err)
+			select {
+			case <-s.ctx.Done():
+				return
+			case <-time.After(restartDelay):
+			}
+			continue
+		}
+		err = s.readSettlementGroupLoop(s.ctx, streamKey, group, consumer, handle)
+		if s.ctx.Err() != nil {
+			return
+		}
+		if err != nil {
+			log.Warnw("lobby: settlement group read loop ended", "stream", streamKey, "err", err)
+		}
 		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case msg, ok := <-msgCh:
-			if !ok {
-				return nil
-			}
-			ev := msg.GetEvent()
-			if ev == nil || ev.GetType() != proto.EventType_TYPE_GAME_COMPLETED {
-				continue
-			}
-			notice := ev.GetGameCompletedNotice()
-			if notice == nil {
-				continue
-			}
-			gameID := notice.GetGameId()
-			if err := s.grpcHandlers.HandleGameCompletedFromRoom(gameID); err != nil {
-				log.Errorw("lobby: game completed settlement failed", "game_id", gameID, "err", err)
-			}
+		case <-s.ctx.Done():
+			return
+		case <-time.After(restartDelay):
 		}
 	}
 }
 
-func (s *Service) readRoomSettlementTournamentStream(ctx context.Context) error {
-	if s.eventStream == nil {
-		return nil
-	}
-	sub := pubsub.NewStreamSubscriber(s.eventStream)
-	msgCh, stop, err := sub.Subscribe(ctx, pubsub.TopicRoomSettlementTournament, pubsub.SubscribeOptions{})
-	if err != nil {
-		return err
-	}
-	defer stop()
-
+// readSettlementGroupLoop reads pending for this consumer ("0"), then idle pending from others (XAUTOCLAIM), then new (">") until ctx done.
+func (s *Service) readSettlementGroupLoop(ctx context.Context, streamKey, group, consumer string, handle func(int64) error) error {
+	claimCursor := "0-0"
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case msg, ok := <-msgCh:
-			if !ok {
-				return nil
+		default:
+		}
+
+		entries, err := s.eventStream.ReadGroup(ctx, streamKey, group, consumer, "0", settlementReadCount, 0)
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(readErrBackoff):
 			}
-			ev := msg.GetEvent()
-			if ev == nil || ev.GetType() != proto.EventType_TYPE_GAME_COMPLETED {
+			continue
+		}
+		if len(entries) == 0 {
+			ac, acErr := s.eventStream.AutoClaim(ctx, streamKey, group, consumer, settlementAutoClaimMinIdleMS, claimCursor, settlementReadCount)
+			if acErr != nil {
+				log.Warnw("lobby: settlement xautoclaim failed", "stream", streamKey, "err", acErr)
+			} else {
+				entries = ac.Entries
+				if ac.NextStart != "" {
+					claimCursor = ac.NextStart
+				}
+				if len(entries) > 0 {
+					log.Infow("lobby: settlement reclaimed idle pending", "stream", streamKey, "count", len(entries))
+				}
+			}
+		}
+		if len(entries) == 0 {
+			entries, err = s.eventStream.ReadGroup(ctx, streamKey, group, consumer, ">", settlementReadCount, settlementBlockMS)
+			if err != nil {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(readErrBackoff):
+				}
 				continue
 			}
-			notice := ev.GetGameCompletedNotice()
-			if notice == nil {
-				continue
+		}
+
+		for _, e := range entries {
+			ack, errProc := processSettlementEntry(e, handle)
+			if !ack {
+				log.Errorw("lobby: settlement handler failed", "stream", streamKey, "msg_id", e.ID, "err", errProc)
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(handlerErrBackoff):
+				}
+				break
 			}
-			gameID := notice.GetGameId()
-			if err := s.grpcHandlers.HandleGameCompletedFromTournamentStream(gameID); err != nil {
-				log.Errorw("lobby: game completed settlement failed", "game_id", gameID, "err", err)
+			if _, err := s.eventStream.Ack(ctx, streamKey, group, e.ID); err != nil {
+				log.Errorw("lobby: settlement xack failed", "stream", streamKey, "msg_id", e.ID, "err", err)
 			}
 		}
 	}
+}
+
+// processSettlementEntry runs handle for TYPE_GAME_COMPLETED. Returns (ack, err): ack false if handler failed (do not ack);
+// ack true if the entry should be acknowledged (success, irrelevant, or unrecoverable bad payload).
+func processSettlementEntry(e stream.Entry, handle func(int64) error) (ack bool, err error) {
+	if len(e.Payload) == 0 {
+		return true, nil
+	}
+	var ev proto.Event
+	if err := goproto.Unmarshal(e.Payload, &ev); err != nil {
+		log.Warnw("lobby: settlement unmarshal failed", "msg_id", e.ID, "err", err)
+		return true, nil
+	}
+	if ev.GetType() != proto.EventType_TYPE_GAME_COMPLETED {
+		return true, nil
+	}
+	notice := ev.GetGameCompletedNotice()
+	if notice == nil {
+		return true, nil
+	}
+	gameID := notice.GetGameId()
+	if gameID == 0 {
+		return true, nil
+	}
+	if err := handle(gameID); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/lobby_server/room_settlement_subscriber_test.go
+++ b/lobby_server/room_settlement_subscriber_test.go
@@ -1,0 +1,270 @@
+package lobbyserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/CryptoElementals/common/pubsub"
+	"github.com/CryptoElementals/common/rpc/proto"
+	"github.com/CryptoElementals/common/stream"
+	goproto "google.golang.org/protobuf/proto"
+	"github.com/stretchr/testify/require"
+)
+
+// streamStub implements [stream.Stream] for unit tests (unused methods return zero values).
+type streamStub struct {
+	mu           sync.Mutex
+	groupCreateN int
+	groupErr     error
+}
+
+func (s *streamStub) Publish(ctx context.Context, streamName string, topic string, payload []byte, ts int64) (string, error) {
+	return "", nil
+}
+func (s *streamStub) Read(ctx context.Context, streamName string, startID string, blockMs int) ([]stream.Entry, error) {
+	return nil, nil
+}
+func (s *streamStub) Trim(ctx context.Context, streamName string, maxAge time.Duration) (int, error) {
+	return 0, nil
+}
+func (s *streamStub) Len(ctx context.Context, streamName string) (int, error) {
+	return 0, nil
+}
+func (s *streamStub) Range(ctx context.Context, streamName string, startID, endID string) ([]stream.Entry, error) {
+	return nil, nil
+}
+func (s *streamStub) GroupCreate(ctx context.Context, streamName, group, startID string, mkstream bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.groupCreateN++
+	if s.groupErr != nil {
+		return s.groupErr
+	}
+	return nil
+}
+func (s *streamStub) GroupDestroy(ctx context.Context, streamName, group string) (int, error) {
+	return 0, nil
+}
+func (s *streamStub) GroupDelConsumer(ctx context.Context, streamName, group, consumer string) (int, error) {
+	return 0, nil
+}
+func (s *streamStub) ReadGroup(ctx context.Context, streamName, group, consumer, readID string, count int, blockMs int) ([]stream.Entry, error) {
+	return nil, nil
+}
+func (s *streamStub) Ack(ctx context.Context, streamName, group string, messageIDs ...string) (int, error) {
+	return 0, nil
+}
+func (s *streamStub) Pending(ctx context.Context, streamName, group string) (stream.PendingSummary, error) {
+	return stream.PendingSummary{}, nil
+}
+func (s *streamStub) Claim(ctx context.Context, streamName, group, consumer string, minIdleMs int, messageIDs ...string) ([]stream.Entry, error) {
+	return nil, nil
+}
+func (s *streamStub) AutoClaim(ctx context.Context, streamName, group, consumer string, minIdleMs int, start string, count int) (stream.AutoClaimResult, error) {
+	return stream.AutoClaimResult{}, nil
+}
+
+func TestEnsureSettlementConsumerGroup_BusyGroupIgnored(t *testing.T) {
+	ctx := context.Background()
+	st := &streamStub{
+		groupErr: errors.New("BUSYGROUP Consumer Group name already exists"),
+	}
+	err := ensureSettlementConsumerGroup(ctx, st, pubsub.TopicRoomSettlementPVP, settlementGroupPVP)
+	require.NoError(t, err)
+	require.Equal(t, 1, st.groupCreateN)
+}
+
+func TestEnsureSettlementConsumerGroup_OtherErrorPropagates(t *testing.T) {
+	ctx := context.Background()
+	want := errors.New("no connection")
+	st := &streamStub{groupErr: want}
+	err := ensureSettlementConsumerGroup(ctx, st, "s", "g")
+	require.ErrorIs(t, err, want)
+}
+
+func TestProcessSettlementEntry_AcksIrrelevant(t *testing.T) {
+	calls := 0
+	handle := func(int64) error {
+		calls++
+		return nil
+	}
+	ack, err := processSettlementEntry(stream.Entry{Payload: []byte("not-proto")}, handle)
+	require.NoError(t, err)
+	require.True(t, ack)
+	require.Zero(t, calls)
+
+	ev := &proto.Event{Type: proto.EventType_TYPE_ROUND_READY}
+	b, err := goproto.Marshal(ev)
+	require.NoError(t, err)
+	ack, err = processSettlementEntry(stream.Entry{Payload: b}, handle)
+	require.NoError(t, err)
+	require.True(t, ack)
+	require.Zero(t, calls)
+}
+
+func TestProcessSettlementEntry_HandlerErrorNoAck(t *testing.T) {
+	ev := &proto.Event{
+		Type: proto.EventType_TYPE_GAME_COMPLETED,
+		Event: &proto.Event_GameCompletedNotice{
+			GameCompletedNotice: &proto.GameCompletedNotice{GameId: 42},
+		},
+	}
+	b, err := goproto.Marshal(ev)
+	require.NoError(t, err)
+	want := errors.New("handler failed")
+	ack, err := processSettlementEntry(stream.Entry{Payload: b}, func(int64) error { return want })
+	require.ErrorIs(t, err, want)
+	require.False(t, ack)
+}
+
+// fakeConsumerGroupStream models Redis XREADGROUP: each new message (">") is delivered to at most one
+// consumer; a second consumer does not see the same message until it is pending-reclaimed (not simulated here).
+type fakeConsumerGroupStream struct {
+	mu           sync.Mutex
+	newMessages  []stream.Entry
+	pel          map[string][]stream.Entry // consumer -> pending (undelivered to ack)
+	acked        map[string]struct{}
+	groupEnsured bool
+}
+
+func newFakeConsumerGroupStream(payloads ...[]byte) *fakeConsumerGroupStream {
+	entries := make([]stream.Entry, len(payloads))
+	for i, p := range payloads {
+		entries[i] = stream.Entry{
+			ID:        fmt.Sprintf("0-%d", i),
+			Topic:     pubsub.TopicRoomSettlementPVP,
+			Payload:   p,
+			Timestamp: time.Now().UnixMilli(),
+		}
+	}
+	return &fakeConsumerGroupStream{
+		newMessages:  entries,
+		pel:          make(map[string][]stream.Entry),
+		acked:        make(map[string]struct{}),
+		groupEnsured: false,
+	}
+}
+
+func (f *fakeConsumerGroupStream) Publish(ctx context.Context, streamName string, topic string, payload []byte, ts int64) (string, error) {
+	return "", nil
+}
+func (f *fakeConsumerGroupStream) Read(ctx context.Context, streamName string, startID string, blockMs int) ([]stream.Entry, error) {
+	return nil, nil
+}
+func (f *fakeConsumerGroupStream) Trim(ctx context.Context, streamName string, maxAge time.Duration) (int, error) {
+	return 0, nil
+}
+func (f *fakeConsumerGroupStream) Len(ctx context.Context, streamName string) (int, error) {
+	return 0, nil
+}
+func (f *fakeConsumerGroupStream) Range(ctx context.Context, streamName string, startID, endID string) ([]stream.Entry, error) {
+	return nil, nil
+}
+func (f *fakeConsumerGroupStream) GroupCreate(ctx context.Context, streamName, group, startID string, mkstream bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.groupEnsured {
+		return errors.New("BUSYGROUP Consumer Group name already exists")
+	}
+	f.groupEnsured = true
+	return nil
+}
+func (f *fakeConsumerGroupStream) GroupDestroy(ctx context.Context, streamName, group string) (int, error) {
+	return 0, nil
+}
+func (f *fakeConsumerGroupStream) GroupDelConsumer(ctx context.Context, streamName, group, consumer string) (int, error) {
+	return 0, nil
+}
+func (f *fakeConsumerGroupStream) ReadGroup(ctx context.Context, streamName, group, consumer, readID string, count int, blockMs int) ([]stream.Entry, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if readID == "0" {
+		out := f.pel[consumer]
+		f.pel[consumer] = nil
+		return out, nil
+	}
+	if readID != ">" {
+		return nil, nil
+	}
+	if len(f.newMessages) == 0 {
+		return nil, nil
+	}
+	e := f.newMessages[0]
+	f.newMessages = f.newMessages[1:]
+	f.pel[consumer] = append(f.pel[consumer], e)
+	return []stream.Entry{e}, nil
+}
+func (f *fakeConsumerGroupStream) Ack(ctx context.Context, streamName, group string, messageIDs ...string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, id := range messageIDs {
+		if _, ok := f.acked[id]; ok {
+			continue
+		}
+		f.acked[id] = struct{}{}
+		n++
+	}
+	return n, nil
+}
+func (f *fakeConsumerGroupStream) Pending(ctx context.Context, streamName, group string) (stream.PendingSummary, error) {
+	return stream.PendingSummary{}, nil
+}
+func (f *fakeConsumerGroupStream) Claim(ctx context.Context, streamName, group, consumer string, minIdleMs int, messageIDs ...string) ([]stream.Entry, error) {
+	return nil, nil
+}
+func (f *fakeConsumerGroupStream) AutoClaim(ctx context.Context, streamName, group, consumer string, minIdleMs int, start string, count int) (stream.AutoClaimResult, error) {
+	return stream.AutoClaimResult{}, nil
+}
+
+// TestConsumerGroupFake_OneMessageOneConsumer models two lobby replicas: only the first XREADGROUP gets the work item.
+func TestConsumerGroupFake_OneMessageOneConsumer(t *testing.T) {
+	ctx := context.Background()
+	key := pubsub.TopicRoomSettlementPVP
+	p := mustMarshalGameCompleted(t, 9001)
+	fake := newFakeConsumerGroupStream(p)
+	require.NoError(t, ensureSettlementConsumerGroup(ctx, fake, key, settlementGroupPVP))
+
+	c1, c2 := "pod-1", "pod-2"
+	got1, err := fake.ReadGroup(ctx, key, settlementGroupPVP, c1, ">", 10, 0)
+	require.NoError(t, err)
+	got2, err := fake.ReadGroup(ctx, key, settlementGroupPVP, c2, ">", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, got1, 1)
+	require.Empty(t, got2)
+}
+
+// TestConsumerGroupFake_TwoMessagesSplit models Redis assigning two new entries across two consumers.
+func TestConsumerGroupFake_TwoMessagesSplit(t *testing.T) {
+	ctx := context.Background()
+	key := pubsub.TopicRoomSettlementPVP
+	fake := newFakeConsumerGroupStream(
+		mustMarshalGameCompleted(t, 1),
+		mustMarshalGameCompleted(t, 2),
+	)
+	require.NoError(t, fake.GroupCreate(ctx, key, settlementGroupPVP, "0", true))
+
+	a, err := fake.ReadGroup(ctx, key, settlementGroupPVP, "c1", ">", 10, 0)
+	require.NoError(t, err)
+	b, err := fake.ReadGroup(ctx, key, settlementGroupPVP, "c2", ">", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, a, 1)
+	require.Len(t, b, 1)
+}
+
+func mustMarshalGameCompleted(t *testing.T, gameID int64) []byte {
+	t.Helper()
+	ev := &proto.Event{
+		Type: proto.EventType_TYPE_GAME_COMPLETED,
+		Event: &proto.Event_GameCompletedNotice{
+			GameCompletedNotice: &proto.GameCompletedNotice{GameId: gameID},
+		},
+	}
+	b, err := goproto.Marshal(ev)
+	require.NoError(t, err)
+	return b
+}

--- a/lobby_server/worker/queue/bots.go
+++ b/lobby_server/worker/queue/bots.go
@@ -78,15 +78,6 @@ func (q *Queue) registerBotDispatchTickHandler() {
 	})
 }
 
-func (q *Queue) scheduleNextBotDispatchTick() {
-	if q.botWaitTime <= 0 {
-		return
-	}
-	if err := timer.ProcessIn(timer.ScopeLobby, q.botWaitTime, &botDispatchTickEvent{}, true); err != nil {
-		log.Errorw("schedule bot dispatch tick failed", "err", err)
-	}
-}
-
 func (q *Queue) handleBotDispatchTick() error {
 	if q.ctx.Err() != nil {
 		return nil
@@ -113,10 +104,6 @@ func (q *Queue) handleBotDispatchTick() error {
 		}
 	}
 	q.lock.Unlock()
-
-	if q.ctx.Err() == nil {
-		q.scheduleNextBotDispatchTick()
-	}
 	return nil
 }
 
@@ -124,5 +111,7 @@ func (q *Queue) addBotRoutine() {
 	if q.botWaitTime <= 0 {
 		return
 	}
-	q.scheduleNextBotDispatchTick()
+	if err := timer.RegisterBotDispatchRecurring(q.botWaitTime, &botDispatchTickEvent{}); err != nil {
+		log.Errorw("register bot dispatch recurring failed", "err", err)
+	}
 }

--- a/lobby_server/worker/queue/queue.go
+++ b/lobby_server/worker/queue/queue.go
@@ -18,6 +18,7 @@ import (
 	"github.com/CryptoElementals/common/pubsub"
 	"github.com/CryptoElementals/common/room_server/worker/types"
 	pb "github.com/CryptoElementals/common/rpc/proto"
+	"github.com/CryptoElementals/common/timer"
 	"google.golang.org/grpc"
 )
 
@@ -110,6 +111,9 @@ func (q *Queue) start() error {
 }
 
 func (q *Queue) close() {
+	if err := timer.UnregisterBotDispatchRecurring(); err != nil {
+		log.Errorw("unregister bot dispatch recurring failed", "err", err)
+	}
 	q.lock.Lock()
 	defer q.lock.Unlock()
 	q.closing = true

--- a/lobby_server/worker/queue/queue.go
+++ b/lobby_server/worker/queue/queue.go
@@ -205,7 +205,8 @@ func (q *Queue) GameResultSettlement(event *types.GameCompletedEvent) error {
 		}
 	})
 	q.lock.Unlock()
-	if err := db.BattleResultSettlement(gr); err != nil {
+	skippedDup, err := db.BattleResultSettlement(gr)
+	if err != nil {
 		log.Errorw("BattleResultSettlement failed", "err", err)
 		return err
 	}
@@ -221,13 +222,16 @@ func (q *Queue) GameResultSettlement(event *types.GameCompletedEvent) error {
 	} else if q.anyHumanPlayerBelowQueueThreshold(gr, bots) {
 		log.Infow("skipping continue rematch: insufficient tokens after settlement", "game_id", gameID)
 		q.publishNotMatchableForHumans(gr, gameID, bots)
-	} else {
+	} else if !skippedDup {
 		q.lock.Lock()
 		q.tryStartContinueRematchAfterGame(gameID, gr)
 		q.lock.Unlock()
 	}
 
 	go func() {
+		if skippedDup {
+			return
+		}
 		if q.statSvcClient == nil {
 			return
 		}

--- a/redis/stream.go
+++ b/redis/stream.go
@@ -18,6 +18,7 @@ const (
 	XACK_COMMAND                  = "XACK"
 	XPENDING_COMMAND              = "XPENDING"
 	XCLAIM_COMMAND                = "XCLAIM"
+	XAUTOCLAIM_COMMAND            = "XAUTOCLAIM"
 	XINFO_COMMAND                 = "XINFO"
 	XGROUP_CREATE_SUBCOMMAND      = "CREATE"
 	XGROUP_DESTROY_SUBCOMMAND     = "DESTROY"
@@ -258,6 +259,24 @@ func XClaim(stream string, group string, consumer string, minIdleTimeMs int, ids
 		args = append(args, id)
 	}
 	return redis.Values(conn.Do(XCLAIM_COMMAND, args...))
+}
+
+// XAutoClaim runs XAUTOCLAIM key group consumer min-idle-time start [COUNT count].
+// Returns the raw Redis array: [next-start, entries...] (entries in XRANGE shape).
+func XAutoClaim(stream string, group string, consumer string, minIdleTimeMs int, start string, count int) ([]interface{}, error) {
+	conn := globalPool.Get()
+	defer func() {
+		err := conn.Close()
+		if err != nil {
+			log.Errorf("redis client close err: %s", err.Error())
+		}
+	}()
+
+	args := []interface{}{stream, group, consumer, minIdleTimeMs, start}
+	if count > 0 {
+		args = append(args, COUNT_OPTION, count)
+	}
+	return redis.Values(conn.Do(XAUTOCLAIM_COMMAND, args...))
 }
 
 func XInfoStream(stream string) ([]interface{}, error) {

--- a/stream/redis_stream.go
+++ b/stream/redis_stream.go
@@ -126,6 +126,24 @@ func (r *RedisStream) Claim(ctx context.Context, stream, group, consumer string,
 	return parseRangeReply(reply)
 }
 
+func (r *RedisStream) AutoClaim(ctx context.Context, streamName, group, consumer string, minIdleMs int, start string, count int) (AutoClaimResult, error) {
+	if start == "" {
+		start = "0-0"
+	}
+	if count <= 0 {
+		count = 100
+	}
+	reply, err := redis.XAutoClaim(streamName, group, consumer, minIdleMs, start, count)
+	if err != nil {
+		return AutoClaimResult{}, err
+	}
+	entries, next, err := parseAutoClaimReply(reply)
+	if err != nil {
+		return AutoClaimResult{}, err
+	}
+	return AutoClaimResult{Entries: entries, NextStart: next}, nil
+}
+
 func (r *RedisStream) Trim(ctx context.Context, stream string, maxAge time.Duration) (int, error) {
 	cutoff := time.Now().Add(-maxAge)
 	minID := fmt.Sprintf("%d-0", cutoff.UnixMilli())
@@ -226,6 +244,39 @@ func parseRangeReply(reply []interface{}) ([]Entry, error) {
 		result = append(result, ent)
 	}
 	return result, nil
+}
+
+// parseAutoClaimReply decodes XAUTOCLAIM reply: [next-start, entries]. Redis 7+ may append more fields; entries stay at index 1.
+func parseAutoClaimReply(reply interface{}) (entries []Entry, nextStart string, err error) {
+	if reply == nil {
+		return nil, "0-0", nil
+	}
+	vals, err := redigo.Values(reply, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("xautoclaim reply: %w", err)
+	}
+	if len(vals) < 2 {
+		return nil, "", fmt.Errorf("xautoclaim reply: expected >=2 elements, got %d", len(vals))
+	}
+	nextStart, err = redigo.String(vals[0], nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("xautoclaim next id: %w", err)
+	}
+	if vals[1] == nil {
+		return nil, nextStart, nil
+	}
+	entryVals, err := redigo.Values(vals[1], nil)
+	if err != nil {
+		return nil, nextStart, fmt.Errorf("xautoclaim entries: %w", err)
+	}
+	if len(entryVals) == 0 {
+		return nil, nextStart, nil
+	}
+	entries, err = parseRangeReply(entryVals)
+	if err != nil {
+		return nil, nextStart, err
+	}
+	return entries, nextStart, nil
 }
 
 func parseStreamEntry(item interface{}) (Entry, error) {

--- a/stream/redis_stream_test.go
+++ b/stream/redis_stream_test.go
@@ -1,0 +1,88 @@
+package stream
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAutoClaimReply(t *testing.T) {
+	payload := []byte("hello")
+	b64 := base64.StdEncoding.EncodeToString(payload)
+	// XAUTOCLAIM uses the same stream-entry layout as XRANGE; redigo StringMap expects []byte values.
+	entry := []interface{}{
+		[]byte("12344-0"),
+		[]interface{}{
+			[]byte("topic"), []byte("room_settlement_PVP"),
+			[]byte("payload"), []byte(b64),
+			[]byte("ts"), []byte("99"),
+		},
+	}
+	reply := []interface{}{
+		[]byte("12345-0"),
+		[]interface{}{entry},
+	}
+	entries, next, err := parseAutoClaimReply(reply)
+	require.NoError(t, err)
+	require.Equal(t, "12345-0", next)
+	require.Len(t, entries, 1)
+	require.Equal(t, "12344-0", entries[0].ID)
+	require.Equal(t, payload, entries[0].Payload)
+	require.Equal(t, int64(99), entries[0].Timestamp)
+}
+
+func TestParseAutoClaimReply_EmptyEntries(t *testing.T) {
+	reply := []interface{}{
+		"0-0",
+		[]interface{}{},
+	}
+	entries, next, err := parseAutoClaimReply(reply)
+	require.NoError(t, err)
+	require.Equal(t, "0-0", next)
+	require.Empty(t, entries)
+}
+
+func TestParseAutoClaimReply_Nil(t *testing.T) {
+	entries, next, err := parseAutoClaimReply(nil)
+	require.NoError(t, err)
+	require.Equal(t, "0-0", next)
+	require.Nil(t, entries)
+}
+
+func TestParseAutoClaimReply_NilEntriesSlice(t *testing.T) {
+	reply := []interface{}{
+		"99-0",
+		nil,
+	}
+	entries, next, err := parseAutoClaimReply(reply)
+	require.NoError(t, err)
+	require.Equal(t, "99-0", next)
+	require.Nil(t, entries)
+}
+
+func TestParseAutoClaimReply_Redis7ExtraFields(t *testing.T) {
+	reply := []interface{}{
+		"0-0",
+		[]interface{}{},
+		[]interface{}{"deleted-id-1"},
+	}
+	entries, next, err := parseAutoClaimReply(reply)
+	require.NoError(t, err)
+	require.Equal(t, "0-0", next)
+	require.Empty(t, entries)
+}
+
+func TestParseAutoClaimReply_ShortReply(t *testing.T) {
+	_, _, err := parseAutoClaimReply([]interface{}{"only-one"})
+	require.Error(t, err)
+}
+
+func TestParseAutoClaimReply_InvalidNested(t *testing.T) {
+	reply := []interface{}{
+		"0-0",
+		"not-an-array",
+	}
+	_, _, err := parseAutoClaimReply(reply)
+	require.Error(t, err)
+}

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -27,6 +27,12 @@ type PendingConsumer struct {
 	Count int64
 }
 
+// AutoClaimResult is the parsed outcome of XAUTOCLAIM (claimed entries + scan cursor).
+type AutoClaimResult struct {
+	Entries   []Entry
+	NextStart string
+}
+
 // Stream abstracts a message stream backend (Redis, Kafka, etc.).
 // Implementations can be swapped without changing callers.
 type Stream interface {
@@ -67,4 +73,8 @@ type Stream interface {
 
 	// Claim takes idle pending messages and assigns them to consumer (XCLAIM). Requires at least one messageID.
 	Claim(ctx context.Context, stream, group, consumer string, minIdleMs int, messageIDs ...string) ([]Entry, error)
+
+	// AutoClaim scans the group's pending list and claims entries idle longer than minIdleMs (XAUTOCLAIM).
+	// start is the scan cursor ("0-0" to begin); use returned NextStart on the next call to continue scanning.
+	AutoClaim(ctx context.Context, stream, group, consumer string, minIdleMs int, start string, count int) (AutoClaimResult, error)
 }

--- a/timer/scheduler.go
+++ b/timer/scheduler.go
@@ -1,0 +1,98 @@
+package timer
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/CryptoElementals/common/log"
+	"github.com/hibiken/asynq"
+)
+
+var (
+	lobbyAsynqScheduler *asynq.Scheduler
+	botDispatchCronID   string
+)
+
+// initAsynqScheduler starts the shared hibiken/asynq process scheduler for
+// periodic lobby jobs. It is invoked from InitTimer(ScopeLobby) when Redis is
+// available. The scheduler uses a separate Redis client from the timer Client.
+func initAsynqScheduler(redisOpt asynq.RedisClientOpt) {
+	if lobbyAsynqScheduler != nil {
+		return
+	}
+	s := asynq.NewScheduler(redisOpt, &asynq.SchedulerOpts{
+		Logger:   &asynqLogger{},
+		LogLevel: asynq.WarnLevel,
+	})
+	if err := s.Start(); err != nil {
+		log.Fatalw("asynq lobby scheduler failed to start", "err", err)
+		return
+	}
+	lobbyAsynqScheduler = s
+}
+
+func shutdownLobbyAsynqScheduler() {
+	s := lobbyAsynqScheduler
+	if s == nil {
+		return
+	}
+	if err := UnregisterBotDispatchRecurring(); err != nil {
+		log.Errorw("unregister bot dispatch cron on scheduler shutdown", "err", err)
+	}
+	lobbyAsynqScheduler = nil
+	s.Shutdown()
+}
+
+// RegisterBotDispatchRecurring registers a single repeating cron job that enqueues
+// queue bot-dispatch work on @every <period> (using robfig/cron "every" syntax).
+// It replaces any previous bot-dispatch registration. Call after InitTimer(ScopeLobby).
+func RegisterBotDispatchRecurring(period time.Duration, evt TimerEvent) error {
+	if period <= 0 || evt == nil {
+		return nil
+	}
+	s := lobbyAsynqScheduler
+	if s == nil {
+		return fmt.Errorf("register bot dispatch: lobby asynq scheduler is not started")
+	}
+	cronSpec := fmt.Sprintf("@every %s", period.String())
+	task := asynq.NewTask(evt.EventType(), evt.Marshal())
+	uniqueTTL := period
+	if uniqueTTL < time.Second {
+		uniqueTTL = time.Second
+	}
+	opts := []asynq.Option{
+		asynq.Queue(queueName(ScopeLobby)),
+		asynq.MaxRetry(0),
+		asynq.Unique(uniqueTTL),
+	}
+	if botDispatchCronID != "" {
+		if err := s.Unregister(botDispatchCronID); err != nil {
+			log.Errorw("unregister previous bot dispatch cron", "err", err)
+		}
+		botDispatchCronID = ""
+	}
+	eid, err := s.Register(cronSpec, task, opts...)
+	if err != nil {
+		return err
+	}
+	botDispatchCronID = eid
+	return nil
+}
+
+// UnregisterBotDispatchRecurring removes the scheduled bot-dispatch job if any
+// (e.g. on queue stop).
+func UnregisterBotDispatchRecurring() error {
+	eid := botDispatchCronID
+	botDispatchCronID = ""
+	if eid == "" {
+		return nil
+	}
+	s := lobbyAsynqScheduler
+	if s == nil {
+		return nil
+	}
+	if err := s.Unregister(eid); err != nil {
+		return err
+	}
+	return nil
+}

--- a/timer/timer.go
+++ b/timer/timer.go
@@ -80,6 +80,7 @@ func InitTimer(scope Scope) {
 		client = asynq.NewClient(redisOpt)
 	}
 
+	initAsynqScheduler(redisOpt)
 	if servers[scope] != nil {
 		return
 	}
@@ -107,6 +108,9 @@ func InitTimer(scope Scope) {
 func StopTimer(scope Scope) {
 	serversMu.Lock()
 	defer serversMu.Unlock()
+	if scope == ScopeLobby {
+		shutdownLobbyAsynqScheduler()
+	}
 	if srv := servers[scope]; srv != nil {
 		srv.Shutdown()
 		delete(servers, scope)


### PR DESCRIPTION
* Run a shared asynq.Scheduler from InitTimer(ScopeLobby); tear it down in StopTimer(ScopeLobby).
Register the bot-dispatch job with @every <bot wait> via RegisterBotDispatchRecurring, and unregister on queue close / shutdown.
* Drop the old ProcessIn + rescheduling fallback and the BotAsynqSchedulerEnabled check; production assumes the lobby timer is initialized first.
* Enqueue with asynq.Unique (TTL ≥ 1s, aligned with ProcessIn) so duplicate ticks are suppressed in the same window.