### PR TITLE
feat: align room server with v3 contract and simplify game flow

### DIFF
--- a/cmd/ele-tools/bot_registry.go
+++ b/cmd/ele-tools/bot_registry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -264,6 +265,64 @@ var botRegistryUpdateStatusCmd = &cobra.Command{
 	},
 }
 
+var botRegistryCleanLastSeenGreaterThanCmd = &cobra.Command{
+	Use:   "clean-last-seen-gt <last_seen_ms>",
+	Short: "Remove all bots with last_seen_ms greater than the provided value",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := initBotRegistryRuntime(); err != nil {
+			fmt.Printf("Failed to initialize bot registry tools: %v\n", err)
+			os.Exit(1)
+		}
+
+		thresholdMs, err := strconv.ParseInt(strings.TrimSpace(args[0]), 10, 64)
+		if err != nil {
+			fmt.Printf("Invalid last_seen_ms %q: %v\n", args[0], err)
+			os.Exit(1)
+		}
+
+		keys := botRegistryKeys(botRegistryNamespace)
+		totalRemoved := 0
+
+		for {
+			members, err := redis.ZRangeByScore(keys.lastSeenKey, fmt.Sprintf("(%d", thresholdMs), "+inf", 0, 1000)
+			if err != nil {
+				fmt.Printf("Failed to query last_seen zset: %v\n", err)
+				os.Exit(1)
+			}
+			if len(members) == 0 {
+				break
+			}
+
+			memberArgs := make([]interface{}, 0, len(members))
+			for _, m := range members {
+				memberArgs = append(memberArgs, m)
+			}
+
+			if _, err := redis.SRem(keys.allKey, memberArgs...); err != nil {
+				fmt.Printf("Failed to remove from all set: %v\n", err)
+				os.Exit(1)
+			}
+			if _, err := redis.SRem(keys.idleKey, memberArgs...); err != nil {
+				fmt.Printf("Failed to remove from idle set: %v\n", err)
+				os.Exit(1)
+			}
+			if _, err := redis.SRem(keys.inGameKey, memberArgs...); err != nil {
+				fmt.Printf("Failed to remove from in-game set: %v\n", err)
+				os.Exit(1)
+			}
+			if _, err := redis.ZRem(keys.lastSeenKey, memberArgs...); err != nil {
+				fmt.Printf("Failed to remove from last_seen zset: %v\n", err)
+				os.Exit(1)
+			}
+
+			totalRemoved += len(members)
+		}
+
+		fmt.Printf("Removed %d bots with last_seen_ms > %d\n", totalRemoved, thresholdMs)
+	},
+}
+
 type botRegistryRedisKeys struct {
 	allKey      string
 	idleKey     string
@@ -332,6 +391,7 @@ func init() {
 	botRegistryCmd.AddCommand(botRegistryAddCmd)
 	botRegistryCmd.AddCommand(botRegistryRemoveCmd)
 	botRegistryCmd.AddCommand(botRegistryUpdateStatusCmd)
+	botRegistryCmd.AddCommand(botRegistryCleanLastSeenGreaterThanCmd)
 
 	botRegistryInspectCmd.Flags().Int64("freshness-sec", 20, "freshness threshold in seconds")
 	botRegistryInspectCmd.PreRun = func(cmd *cobra.Command, args []string) {

--- a/cmd/ele-tools/chain_tx_pool_cleanup.go
+++ b/cmd/ele-tools/chain_tx_pool_cleanup.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/CryptoElementals/common/config"
+	"github.com/CryptoElementals/common/db"
+	"github.com/CryptoElementals/common/log"
+	dao "github.com/CryptoElementals/common/models"
+	"github.com/spf13/cobra"
+)
+
+var (
+	chainTxPoolCleanupBefore  string
+	chainTxPoolCleanupDays    int
+	chainTxPoolCleanupExecute bool
+	chainTxPoolCleanupBatch   int
+)
+
+var chainTxPoolCleanupCmd = &cobra.Command{
+	Use:   "cleanup-tx-pool",
+	Short: "Hard-delete soft-deleted chain_tx_pool_items before a cutoff time",
+	Long: `Permanently deletes rows from chain_tx_pool_items that were previously soft-deleted
+and have deleted_at earlier than the cutoff time.
+
+By default this is a dry-run that only prints the count; pass --execute to actually delete.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := config.InitToolsConfig(configPath); err != nil {
+			fmt.Printf("Failed to load config: %v\n", err)
+			os.Exit(1)
+		}
+
+		logCfg := &log.Config{Level: "info", Development: false}
+		if err := log.InitGlobalLogger(logCfg); err != nil {
+			fmt.Printf("Failed to initialize logger: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := db.Init(&config.ToolsGConf.DbCfg); err != nil {
+			fmt.Printf("Failed to initialize database: %v\n", err)
+			os.Exit(1)
+		}
+
+		before, err := resolveCleanupCutoff(chainTxPoolCleanupBefore, chainTxPoolCleanupDays)
+		if err != nil {
+			fmt.Printf("Invalid cutoff options: %v\n", err)
+			os.Exit(1)
+		}
+
+		if chainTxPoolCleanupBatch <= 0 {
+			chainTxPoolCleanupBatch = 5000
+		}
+
+		q := db.Get().Unscoped().
+			Model(&dao.ChainTxPoolItem{}).
+			Where("deleted_at IS NOT NULL").
+			Where("deleted_at < ?", before)
+
+		var n int64
+		if err := q.Count(&n).Error; err != nil {
+			fmt.Printf("Failed to count rows: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Found %d soft-deleted chain_tx_pool_items row(s) with deleted_at < %s\n", n, before.UTC().Format(time.RFC3339))
+		if !chainTxPoolCleanupExecute {
+			fmt.Println("Dry-run only. Re-run with --execute to delete them.")
+			return
+		}
+		if n == 0 {
+			return
+		}
+
+		type idRow struct{ ID uint }
+		var deleted int64
+		for {
+			var rows []idRow
+			err := q.Select("id").Order("id").Limit(chainTxPoolCleanupBatch).Find(&rows).Error
+			if err != nil {
+				fmt.Printf("Failed to load batch ids: %v\n", err)
+				os.Exit(1)
+			}
+			if len(rows) == 0 {
+				break
+			}
+
+			ids := make([]uint, 0, len(rows))
+			for i := range rows {
+				ids = append(ids, rows[i].ID)
+			}
+
+			res := db.Get().Unscoped().Where("id IN ?", ids).Delete(&dao.ChainTxPoolItem{})
+			if res.Error != nil {
+				fmt.Printf("Failed to delete batch: %v\n", res.Error)
+				os.Exit(1)
+			}
+			deleted += res.RowsAffected
+		}
+
+		fmt.Printf("Deleted %d chain_tx_pool_items row(s)\n", deleted)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(chainTxPoolCleanupCmd)
+	chainTxPoolCleanupCmd.Flags().StringVarP(&configPath, "config", "c", "", "config file path")
+	chainTxPoolCleanupCmd.MarkFlagRequired("config")
+
+	chainTxPoolCleanupCmd.Flags().StringVar(&chainTxPoolCleanupBefore, "before", "", "explicit cutoff time (RFC3339, '2006-01-02', '2006-01-02 15:04:05', or unix seconds)")
+	chainTxPoolCleanupCmd.Flags().IntVar(&chainTxPoolCleanupDays, "days", -1, "delete records soft-deleted before UTC midnight of (today - days); use 0 for before today")
+
+	chainTxPoolCleanupCmd.Flags().BoolVar(&chainTxPoolCleanupExecute, "execute", false, "actually delete rows (default: dry-run)")
+	chainTxPoolCleanupCmd.Flags().IntVar(&chainTxPoolCleanupBatch, "batch", 5000, "batch size for deletes")
+}
+
+func parseFlexibleTime(s string) (time.Time, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, fmt.Errorf("empty time")
+	}
+
+	// unix seconds
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil && len(s) >= 9 {
+		return time.Unix(n, 0).UTC(), nil
+	}
+
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC(), nil
+	}
+	if t, err := time.ParseInLocation("2006-01-02 15:04:05", s, time.UTC); err == nil {
+		return t.UTC(), nil
+	}
+	if t, err := time.ParseInLocation("2006-01-02", s, time.UTC); err == nil {
+		return t.UTC(), nil
+	}
+
+	return time.Time{}, fmt.Errorf("unsupported time format %q", s)
+}
+
+func resolveCleanupCutoff(beforeRaw string, days int) (time.Time, error) {
+	beforeRaw = strings.TrimSpace(beforeRaw)
+	hasBefore := beforeRaw != ""
+	hasDays := days >= 0
+
+	if hasBefore && hasDays {
+		return time.Time{}, fmt.Errorf("use either --before or --days, not both")
+	}
+	if !hasBefore && !hasDays {
+		return time.Time{}, fmt.Errorf("one of --before or --days is required")
+	}
+	if hasBefore {
+		return parseFlexibleTime(beforeRaw)
+	}
+	if days < 0 {
+		return time.Time{}, fmt.Errorf("--days must be greater than or equal to 0")
+	}
+
+	nowUTC := time.Now().UTC()
+	todayUTC := time.Date(nowUTC.Year(), nowUTC.Month(), nowUTC.Day(), 0, 0, 0, 0, time.UTC)
+	return todayUTC.AddDate(0, 0, -days), nil
+}
+

--- a/lobby_server/roomclient/game_creator.go
+++ b/lobby_server/roomclient/game_creator.go
@@ -32,3 +32,43 @@ func (c *GameCreator) CreateGameAndRun(players []types.PlayerAddress, gameType p
 	}
 	return resp.GameId, nil
 }
+
+func (c *GameCreator) CreatePVPGameAndRun(players []types.PlayerAddress, completedMatchID int64) (int64, error) {
+	if c.Client == nil {
+		return 0, status.Error(codes.Unavailable, "room worker client not configured")
+	}
+	req := &proto.CreateGameAndRunRequest{
+		GameType:         uint32(proto.GameType_PVP),
+		CompletedMatchId: completedMatchID,
+	}
+	for i := range players {
+		p := players[i]
+		req.Players = append(req.Players, (&p).ToProto())
+	}
+	resp, err := c.Client.CreateGameAndRun(context.Background(), req)
+	if err != nil {
+		return 0, err
+	}
+	return resp.GameId, nil
+}
+
+func (c *GameCreator) CreateTournamentGameAndRun(players []types.PlayerAddress, completedMatchID int64, tournamentID int64, tierNo int64) (int64, error) {
+	if c.Client == nil {
+		return 0, status.Error(codes.Unavailable, "room worker client not configured")
+	}
+	req := &proto.CreateGameAndRunRequest{
+		GameType:         uint32(proto.GameType_TOURNAMENT),
+		CompletedMatchId: completedMatchID,
+		TournamentId:     tournamentID,
+		TierNo:           tierNo,
+	}
+	for i := range players {
+		p := players[i]
+		req.Players = append(req.Players, (&p).ToProto())
+	}
+	resp, err := c.Client.CreateGameAndRun(context.Background(), req)
+	if err != nil {
+		return 0, err
+	}
+	return resp.GameId, nil
+}

--- a/lobby_server/server.go
+++ b/lobby_server/server.go
@@ -62,7 +62,8 @@ func New(ctx context.Context, cfg *config.LobbyServerConfig) (*Service, error) {
 	if err != nil {
 		return nil, fmt.Errorf("redis stream: %w", err)
 	}
-	eventPub := pubsub.NewStreamPublisher(st)
+	lobbyEventPub := pubsub.NewStreamPublisher(st, pubsub.TopicLobby)
+	tournamentRosterPub := pubsub.NewStreamPublisher(st, pubsub.TopicTournamentRoster)
 	s.eventStream = st
 
 	botStore, err := bot_manager.NewRedisStore("")
@@ -74,7 +75,7 @@ func New(ctx context.Context, cfg *config.LobbyServerConfig) (*Service, error) {
 		tokenTh = int64(cfg.TournamentCfg.EntryFee)
 	}
 	botStore.SetTokenInsufficientThreshold(tokenTh)
-	queueSvc, err := queue.NewService(ctx, eventPub, botStore, gc,
+	queueSvc, err := queue.NewService(ctx, lobbyEventPub, botStore, gc,
 		cfg.MinTokenToJoinQueue,
 		argsTemplate.ConfirmationTimeout,
 		argsTemplate.GameContinueTimeout,
@@ -88,7 +89,7 @@ func New(ctx context.Context, cfg *config.LobbyServerConfig) (*Service, error) {
 	}
 	s.queueSvc = queueSvc
 
-	s.tournamentSvc = tournament.NewTournamentQueueService(ctx, eventPub, botStore, gc,
+	s.tournamentSvc = tournament.NewTournamentQueueService(ctx, lobbyEventPub, tournamentRosterPub, botStore, gc,
 		cfg.TournamentCfg.EntryFee,
 		cfg.TournamentCfg.MinPlayersRequired,
 		cfg.TournamentCfg.IntervalSeconds,

--- a/lobby_server/worker/queue/match.go
+++ b/lobby_server/worker/queue/match.go
@@ -81,7 +81,7 @@ func (q *Queue) publishMatchPending(matchID int64, players []types.PlayerAddress
 			GameMatched: gm,
 		},
 	}
-	if err := pubsub.Publish(q.ctx, q.publisher, pubsub.TopicLobby, out); err != nil {
+	if err := pubsub.Publish(q.ctx, q.publisher, out); err != nil {
 		log.Errorw("publish match pending failed", "topic", pubsub.TopicLobby, "err", err)
 	}
 }
@@ -102,7 +102,7 @@ func (q *Queue) publishMatchCanceled(matchID int64, players []types.PlayerAddres
 			},
 		},
 	}
-	if err := pubsub.Publish(q.ctx, q.publisher, pubsub.TopicLobby, out); err != nil {
+	if err := pubsub.Publish(q.ctx, q.publisher, out); err != nil {
 		log.Errorw("publish match canceled failed", "topic", pubsub.TopicLobby, "err", err)
 	}
 }

--- a/lobby_server/worker/queue/match.go
+++ b/lobby_server/worker/queue/match.go
@@ -184,12 +184,7 @@ func (q *Queue) finalizeConfirmedGameMatch(m *dao.GameMatch) error {
 		*types.NewPlayerAddress(claimedRow.Player1ID, claimedRow.Player1TempAddress),
 		*types.NewPlayerAddress(claimedRow.Player2ID, claimedRow.Player2TempAddress),
 	}
-	gt := claimedRow.GameType
-	gameType := pb.GameType(gt)
-	if gameType == pb.GameType_GAME_TYPE_UNKNOWN {
-		gameType = pb.GameType_PVP
-	}
-	gid, err := q.gameCreator.CreateGameAndRun(players, gameType, m.ID)
+	gid, err := q.gameCreator.CreatePVPGameAndRun(players, m.ID)
 	if err != nil {
 		if revErr := db.RevertGameMatchToPending(q.ctx, m.ID); revErr != nil {
 			log.Errorw("revert game_match after failed game create", "match_id", m.ID, "err", revErr)

--- a/lobby_server/worker/queue/queue.go
+++ b/lobby_server/worker/queue/queue.go
@@ -44,7 +44,7 @@ type Queue struct {
 }
 
 type GameCreator interface {
-	CreateGameAndRun(players []types.PlayerAddress, gameType pb.GameType, completedMatchID int64) (int64, error)
+	CreatePVPGameAndRun(players []types.PlayerAddress, completedMatchID int64) (int64, error)
 }
 
 func NewQueue(

--- a/lobby_server/worker/queue/queue.go
+++ b/lobby_server/worker/queue/queue.go
@@ -327,7 +327,7 @@ func (q *Queue) publishGameSettlementResult(gameID int64, gr *dao.GameResult) {
 			},
 		},
 	}
-	if err := pubsub.Publish(q.ctx, q.publisher, pubsub.TopicLobby, out); err != nil {
+	if err := pubsub.Publish(q.ctx, q.publisher, out); err != nil {
 		log.Errorw("publish game settlement result failed", "topic", pubsub.TopicLobby, "game_id", gameID, "err", err)
 	}
 }
@@ -348,7 +348,7 @@ func (q *Queue) publishNotMatchableForHumans(gr *dao.GameResult, lastGameID int6
 			NotMatchable: &pb.NotMatchable{LastGameId: lastGameID},
 		},
 	}
-	if err := pubsub.Publish(q.ctx, q.publisher, pubsub.TopicLobby, evt); err != nil {
+	if err := pubsub.Publish(q.ctx, q.publisher, evt); err != nil {
 		log.Errorw("publish not matchable failed", "topic", pubsub.TopicLobby, "last_game_id", lastGameID, "err", err)
 	}
 }

--- a/lobby_server/worker/queue/queue_test.go
+++ b/lobby_server/worker/queue/queue_test.go
@@ -23,9 +23,11 @@ var testMiniRedis *miniredis.Miniredis
 // noopEventPublisher satisfies EventPublisher for tests (non-nil publisher required).
 type noopEventPublisher struct{}
 
-func (noopEventPublisher) Publish(ctx context.Context, req *proto.PublishRequest) (*proto.PublishResponse, error) {
+func (noopEventPublisher) Publish(_ context.Context, _ *proto.Event) (*proto.PublishResponse, error) {
 	return &proto.PublishResponse{Success: true}, nil
 }
+
+func (noopEventPublisher) Topic() string { return "test-topic" }
 
 func TestMain(m *testing.M) {
 	if err := snowflake.Init(1); err != nil {

--- a/lobby_server/worker/queue/queue_test.go
+++ b/lobby_server/worker/queue/queue_test.go
@@ -85,7 +85,7 @@ func TestGameMatched(t *testing.T) {
 	testMiniRedis.FlushAll()
 	ctrl := gomock.NewController(t)
 	gameCreator := tt.NewMockGameCreator(ctrl)
-	gameCreator.EXPECT().CreateGameAndRun(gomock.Any(), gomock.Any(), gomock.Any()).Return(int64(1), nil).Times(1)
+	gameCreator.EXPECT().CreatePVPGameAndRun(gomock.Any(), gomock.Any()).Return(int64(1), nil).Times(1)
 	var err error
 	globalTestQueueService, err = NewService(context.Background(), noopEventPublisher{}, nil, gameCreator, 0, 60, 0, 0, 0, 0, "")
 	require.NoError(t, err)

--- a/lobby_server/worker/tournament/coordinator.go
+++ b/lobby_server/worker/tournament/coordinator.go
@@ -69,7 +69,8 @@ type GameCreator interface {
 type coordinator struct {
 	ctx                context.Context
 	cancel             context.CancelFunc
-	publisher          pubsub.Publisher
+	lobbyPublisher     pubsub.Publisher
+	rosterPublisher    pubsub.Publisher
 	botStore           *bot_manager.RedisStore
 	joinTournamentFunc func(tournamentID string, req *proto.PlayerAddress) error
 	gameCreator        GameCreator
@@ -87,12 +88,13 @@ type coordinator struct {
 	lastDisabledLogUnixSec    atomic.Int64
 }
 
-func newCoordinator(parent context.Context, publisher pubsub.Publisher, botStore *bot_manager.RedisStore, gameCreator GameCreator, entryFee int32, minPlayersRequired uint32, intervalSeconds uint32, beforeStartSeconds uint32, botFillWindowSeconds uint32, botFillIntervalSeconds uint32, botFreshnessSec int64) *coordinator {
+func newCoordinator(parent context.Context, lobbyPublisher pubsub.Publisher, rosterPublisher pubsub.Publisher, botStore *bot_manager.RedisStore, gameCreator GameCreator, entryFee int32, minPlayersRequired uint32, intervalSeconds uint32, beforeStartSeconds uint32, botFillWindowSeconds uint32, botFillIntervalSeconds uint32, botFreshnessSec int64) *coordinator {
 	ctx, cancel := context.WithCancel(parent)
 	tc := &coordinator{
 		ctx:                ctx,
 		cancel:             cancel,
-		publisher:          publisher,
+		lobbyPublisher:     lobbyPublisher,
+		rosterPublisher:    rosterPublisher,
 		botStore:           botStore,
 		gameCreator:        gameCreator,
 		entryFee:           entryFee,
@@ -695,7 +697,7 @@ func (tc *coordinator) publishTournamentMatchOutcome(o *tournamentMatchOutcomeTo
 			},
 		},
 	}
-	if err := pubsub.Publish(tc.ctx, tc.publisher, pubsub.TopicLobby, evt); err != nil {
+	if err := pubsub.Publish(tc.ctx, tc.lobbyPublisher, evt); err != nil {
 		log.Errorw("tournament: publish match outcome failed", "game_id", o.gameID, "err", err)
 	}
 }
@@ -704,8 +706,8 @@ func (tc *coordinator) publishTournamentRosterUpdate(tournamentID string) error 
 	if tc == nil {
 		return fmt.Errorf("nil coordinator")
 	}
-	if tc.publisher == nil {
-		return fmt.Errorf("nil publisher")
+	if tc.rosterPublisher == nil {
+		return fmt.Errorf("nil roster publisher")
 	}
 	if tournamentID == "" {
 		return fmt.Errorf("empty tournament id")
@@ -716,7 +718,7 @@ func (tc *coordinator) publishTournamentRosterUpdate(tournamentID string) error 
 			TournamentRosterUpdate: &proto.TournamentRosterUpdate{TournamentID: tournamentID},
 		},
 	}
-	if err := pubsub.Publish(tc.ctx, tc.publisher, pubsub.TopicTournamentRoster, evt); err != nil {
+	if err := pubsub.Publish(tc.ctx, tc.rosterPublisher, evt); err != nil {
 		log.Errorw("tournament: publish roster update failed", "tournament_id", tournamentID, "err", err)
 		return err
 	}

--- a/lobby_server/worker/tournament/service.go
+++ b/lobby_server/worker/tournament/service.go
@@ -25,10 +25,10 @@ type TournamentQueueService struct {
 }
 
 // NewTournamentQueueService constructs the tournament worker. Call Start after DB is ready.
-func NewTournamentQueueService(ctx context.Context, publisher pubsub.Publisher, botStore *bot_manager.RedisStore, gameCreator GameCreator, entryFee int32, minPlayersRequired uint32, intervalSeconds uint32, beforeStartSeconds uint32, botFillWindowSeconds uint32, botFillIntervalSeconds uint32, botFreshnessSec int64) *TournamentQueueService {
+func NewTournamentQueueService(ctx context.Context, lobbyPublisher pubsub.Publisher, rosterPublisher pubsub.Publisher, botStore *bot_manager.RedisStore, gameCreator GameCreator, entryFee int32, minPlayersRequired uint32, intervalSeconds uint32, beforeStartSeconds uint32, botFillWindowSeconds uint32, botFillIntervalSeconds uint32, botFreshnessSec int64) *TournamentQueueService {
 	svc := &TournamentQueueService{
 		ctx:   ctx,
-		coord: newCoordinator(ctx, publisher, botStore, gameCreator, entryFee, minPlayersRequired, intervalSeconds, beforeStartSeconds, botFillWindowSeconds, botFillIntervalSeconds, botFreshnessSec),
+		coord: newCoordinator(ctx, lobbyPublisher, rosterPublisher, botStore, gameCreator, entryFee, minPlayersRequired, intervalSeconds, beforeStartSeconds, botFillWindowSeconds, botFillIntervalSeconds, botFreshnessSec),
 	}
 	svc.coord.joinTournamentFunc = func(tournamentID string, req *proto.PlayerAddress) error {
 		return svc.handleJoinTournamentEvent(tournamentID, req, true)

--- a/lobby_server/worker/tournament/tournament_test.go
+++ b/lobby_server/worker/tournament/tournament_test.go
@@ -19,9 +19,11 @@ func (n *noopGameCreator) CreateGameAndRun(_ []types.PlayerAddress, _ proto.Game
 	return 1, nil
 }
 
-func (noopPublisher) Publish(_ context.Context, _ *proto.PublishRequest) (*proto.PublishResponse, error) {
+func (noopPublisher) Publish(_ context.Context, _ *proto.Event) (*proto.PublishResponse, error) {
 	return &proto.PublishResponse{Success: true}, nil
 }
+
+func (noopPublisher) Topic() string { return "test-topic" }
 
 func setupSQLite(t *testing.T) {
 	t.Helper()
@@ -61,7 +63,7 @@ func TestHandleJoinTournamentEvent_Success(t *testing.T) {
 	seedProfileAndToken(t, 5001, "p5001", 5000)
 	seedTournament(t, "tour-success", time.Now().Add(10*time.Minute))
 
-	svc := NewTournamentQueueService(context.Background(), noopPublisher{}, nil, &noopGameCreator{}, 1000, 2, 3600, 180, 180, 15, 10)
+	svc := NewTournamentQueueService(context.Background(), noopPublisher{}, noopPublisher{}, nil, &noopGameCreator{}, 1000, 2, 3600, 180, 180, 15, 10)
 	req := &proto.PlayerAddress{Id: 5001, TemporaryAddress: " 0xABCDEF "}
 	require.NoError(t, svc.HandleJoinTournamentEvent("tour-success", req))
 
@@ -87,7 +89,7 @@ func TestHandleJoinTournamentEvent_DuplicateJoinRejected(t *testing.T) {
 	seedProfileAndToken(t, 5002, "p5002", 5000)
 	seedTournament(t, "tour-dup", time.Now().Add(10*time.Minute))
 
-	svc := NewTournamentQueueService(context.Background(), noopPublisher{}, nil, &noopGameCreator{}, 1000, 2, 3600, 180, 180, 15, 10)
+	svc := NewTournamentQueueService(context.Background(), noopPublisher{}, noopPublisher{}, nil, &noopGameCreator{}, 1000, 2, 3600, 180, 180, 15, 10)
 	req := &proto.PlayerAddress{Id: 5002, TemporaryAddress: "0xdup"}
 	require.NoError(t, svc.HandleJoinTournamentEvent("tour-dup", req))
 
@@ -107,7 +109,7 @@ func TestHandleJoinTournamentEvent_RejectWhenDeadlineExceeded(t *testing.T) {
 	seedProfileAndToken(t, 5003, "p5003", 5000)
 	seedTournament(t, "tour-expired", time.Now().Add(-1*time.Minute))
 
-	svc := NewTournamentQueueService(context.Background(), noopPublisher{}, nil, &noopGameCreator{}, 1000, 2, 3600, 180, 180, 15, 10)
+	svc := NewTournamentQueueService(context.Background(), noopPublisher{}, noopPublisher{}, nil, &noopGameCreator{}, 1000, 2, 3600, 180, 180, 15, 10)
 	err := svc.HandleJoinTournamentEvent("tour-expired", &proto.PlayerAddress{Id: 5003, TemporaryAddress: "0xlate"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "registration deadline has passed")
@@ -124,7 +126,7 @@ func TestHandleJoinTournamentEvent_RejectWhenTokenNotEnough(t *testing.T) {
 	seedProfileAndToken(t, 5004, "p5004", 500)
 	seedTournament(t, "tour-no-token", time.Now().Add(10*time.Minute))
 
-	svc := NewTournamentQueueService(context.Background(), noopPublisher{}, nil, &noopGameCreator{}, 1000, 2, 3600, 180, 180, 15, 10)
+	svc := NewTournamentQueueService(context.Background(), noopPublisher{}, noopPublisher{}, nil, &noopGameCreator{}, 1000, 2, 3600, 180, 180, 15, 10)
 	err := svc.HandleJoinTournamentEvent("tour-no-token", &proto.PlayerAddress{Id: 5004, TemporaryAddress: "0xpoor"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "user token amount is not enough")

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -10,19 +10,21 @@ import (
 
 // Publisher is the minimal surface for pushing a proto.Event to a topic.
 type Publisher interface {
-	Publish(ctx context.Context, req *proto.PublishRequest) (*proto.PublishResponse, error)
+	Publish(ctx context.Context, evt *proto.Event) (*proto.PublishResponse, error)
+	Topic() string
 }
 
-// Publish sends evt to topic. Nil publisher or nil event is a no-op.
-func Publish(ctx context.Context, pub Publisher, topic string, evt *proto.Event) error {
+// Publish sends evt to pub.Topic(). Nil publisher or nil event is a no-op.
+func Publish(ctx context.Context, pub Publisher, evt *proto.Event) error {
 	if pub == nil || evt == nil {
 		return nil
 	}
+	topic := pub.Topic()
 	if topic == TopicRoom || topic == TopicLobby || topic == TopicTournamentRoster {
 		if evt.MessageId == "" {
 			evt.MessageId = BuildEventMessageID(evt)
 		}
 	}
-	_, err := pub.Publish(ctx, &proto.PublishRequest{Topic: topic, Event: evt})
+	_, err := pub.Publish(ctx, evt)
 	return err
 }

--- a/pubsub/stream_publisher.go
+++ b/pubsub/stream_publisher.go
@@ -10,6 +10,12 @@ import (
 	goproto "google.golang.org/protobuf/proto"
 )
 
+const (
+	streamTrimInterval  = 24 * time.Hour
+	streamMessageMaxAge = 24 * time.Hour
+	streamTrimTimeout   = 30 * time.Second
+)
+
 // StreamPublisher adapts a Stream backend into [Publisher]. The Redis stream key is
 // exactly req.Topic (same string used by [StreamSubscriber]).
 type StreamPublisher struct {
@@ -20,7 +26,9 @@ type StreamPublisher struct {
 // NewStreamPublisher creates a publisher that writes proto.Event messages into
 // the underlying Stream, one stream per topic.
 func NewStreamPublisher(s stream.Stream, topic string) *StreamPublisher {
-	return &StreamPublisher{stream: s, topic: topic}
+	p := &StreamPublisher{stream: s, topic: topic}
+	p.startCleaner()
+	return p
 }
 
 func (p *StreamPublisher) Topic() string {
@@ -51,4 +59,28 @@ func (p *StreamPublisher) Publish(ctx context.Context, evt *proto.Event) (*proto
 		MessageId: msgID,
 		Success:   true,
 	}, nil
+}
+
+func (p *StreamPublisher) startCleaner() {
+	go func() {
+		p.trimOldMessages()
+
+		ticker := time.NewTicker(streamTrimInterval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			p.trimOldMessages()
+		}
+	}()
+}
+
+func (p *StreamPublisher) trimOldMessages() {
+	if p.topic == "" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), streamTrimTimeout)
+	defer cancel()
+
+	_, _ = p.stream.Trim(ctx, p.topic, streamMessageMaxAge)
 }

--- a/pubsub/stream_publisher.go
+++ b/pubsub/stream_publisher.go
@@ -14,30 +14,35 @@ import (
 // exactly req.Topic (same string used by [StreamSubscriber]).
 type StreamPublisher struct {
 	stream stream.Stream
+	topic  string
 }
 
 // NewStreamPublisher creates a publisher that writes proto.Event messages into
 // the underlying Stream, one stream per topic.
-func NewStreamPublisher(s stream.Stream) *StreamPublisher {
-	return &StreamPublisher{stream: s}
+func NewStreamPublisher(s stream.Stream, topic string) *StreamPublisher {
+	return &StreamPublisher{stream: s, topic: topic}
 }
 
-// Publish serializes the proto.Event and writes it to the stream keyed by req.Topic.
-func (p *StreamPublisher) Publish(ctx context.Context, req *proto.PublishRequest) (*proto.PublishResponse, error) {
-	if req.Topic == "" {
+func (p *StreamPublisher) Topic() string {
+	return p.topic
+}
+
+// Publish serializes the proto.Event and writes it to the stream keyed by Topic().
+func (p *StreamPublisher) Publish(ctx context.Context, evt *proto.Event) (*proto.PublishResponse, error) {
+	if p.topic == "" {
 		return nil, fmt.Errorf("topic is required")
 	}
-	if req.Event == nil {
+	if evt == nil {
 		return nil, fmt.Errorf("event is required")
 	}
 
-	payload, err := goproto.Marshal(req.Event)
+	payload, err := goproto.Marshal(evt)
 	if err != nil {
 		return nil, fmt.Errorf("marshal event: %w", err)
 	}
 
 	ts := time.Now().UnixMilli()
-	msgID, err := p.stream.Publish(ctx, req.Topic, req.Topic, payload, ts)
+	msgID, err := p.stream.Publish(ctx, p.topic, p.topic, payload, ts)
 	if err != nil {
 		return nil, fmt.Errorf("stream publish: %w", err)
 	}

--- a/room_server/server.go
+++ b/room_server/server.go
@@ -52,9 +52,11 @@ func New(ctx context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("redis stream: %w", err)
 	}
-	eventPub := pubsub.NewStreamPublisher(st)
-	s.gameSvc = game.NewService(ctx, eventPub, cfg.GameArgsID, chainSvc)
-	s.gameSvc.SetGameResultSettler(newSettlementStreamPublisher(ctx, eventPub))
+	roomEventPub := pubsub.NewStreamPublisher(st, pubsub.TopicRoom)
+	settlementPVPPub := pubsub.NewStreamPublisher(st, pubsub.TopicRoomSettlementPVP)
+	settlementTournamentPub := pubsub.NewStreamPublisher(st, pubsub.TopicRoomSettlementTournament)
+	s.gameSvc = game.NewService(ctx, roomEventPub, cfg.GameArgsID, chainSvc)
+	s.gameSvc.SetGameResultSettler(newSettlementStreamPublisher(ctx, settlementPVPPub, settlementTournamentPub))
 	server := grpc.NewServer(grpc.UnaryInterceptor(middleware.UnaryServerInterceptor))
 	// game.Service implements chain/player/game handlers.
 	rpcServer := rpc.NewRpc(s.gameSvc)

--- a/room_server/settlement_stream.go
+++ b/room_server/settlement_stream.go
@@ -12,16 +12,17 @@ import (
 
 // settlementStreamPublisher notifies the lobby via the room Pub/Sub stream ([pubsub.TopicRoomSettlementPVP]) when a game ends.
 type settlementStreamPublisher struct {
-	ctx context.Context
-	pub game.Publisher
+	ctx           context.Context
+	pvpPub        game.Publisher
+	tournamentPub game.Publisher
 }
 
-func newSettlementStreamPublisher(ctx context.Context, pub game.Publisher) *settlementStreamPublisher {
-	return &settlementStreamPublisher{ctx: ctx, pub: pub}
+func newSettlementStreamPublisher(ctx context.Context, pvpPub game.Publisher, tournamentPub game.Publisher) *settlementStreamPublisher {
+	return &settlementStreamPublisher{ctx: ctx, pvpPub: pvpPub, tournamentPub: tournamentPub}
 }
 
 func (p *settlementStreamPublisher) GameResultSettlement(evt *types.GameCompletedEvent) error {
-	if p.pub == nil || evt == nil || evt.GameID == 0 {
+	if evt == nil || evt.GameID == 0 {
 		return nil
 	}
 	out := &proto.Event{
@@ -36,9 +37,9 @@ func (p *settlementStreamPublisher) GameResultSettlement(evt *types.GameComplete
 	}
 	switch gt {
 	case proto.GameType_TOURNAMENT:
-		return pubsub.Publish(p.ctx, p.pub, pubsub.TopicRoomSettlementTournament, out)
+		return pubsub.Publish(p.ctx, p.tournamentPub, out)
 	case proto.GameType_PVP:
-		return pubsub.Publish(p.ctx, p.pub, pubsub.TopicRoomSettlementPVP, out)
+		return pubsub.Publish(p.ctx, p.pvpPub, out)
 	default:
 		return fmt.Errorf("unknown game type: %d", evt.GameType)
 	}

--- a/room_server/worker/game/publish.go
+++ b/room_server/worker/game/publish.go
@@ -42,13 +42,13 @@ func (g *Game) publishPartialReadyToOtherPlayers(readyAddress types.PlayerAddres
 }
 
 func (g *Game) publishProto(evt *proto.Event) {
-	if err := pubsub.Publish(g.ctx, g.publisher, pubsub.TopicRoom, evt); err != nil {
+	if err := pubsub.Publish(g.ctx, g.publisher, evt); err != nil {
 		log.Errorw("publish failed", "topic", pubsub.TopicRoom, "eventType", evt.Type.String(), "err", err)
 	}
 }
 
 func (r *GameManager) syncGamePhasePublish(address types.PlayerAddress, gamePhase *proto.GamePhase) error {
-	return pubsub.Publish(r.ctx, r.publisher, pubsub.TopicRoom, &proto.Event{
+	return pubsub.Publish(r.ctx, r.publisher, &proto.Event{
 		Type:      proto.EventType_TYPE_GAME_PHASE_SYNC,
 		Receivers: []*proto.PlayerAddress{address.ToProto()},
 		Event: &proto.Event_GamePhase{

--- a/room_server/worker/game/timeout_test.go
+++ b/room_server/worker/game/timeout_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/CryptoElementals/common/pubsub"
 	"github.com/CryptoElementals/common/rpc/proto"
 	dao "github.com/CryptoElementals/common/models"
 	"github.com/CryptoElementals/common/room_server/worker/types"
@@ -20,9 +21,11 @@ func (noopTxPool) ClearGameInfo(_ int64)                                      {}
 
 type nopPublisher struct{}
 
-func (nopPublisher) Publish(_ context.Context, _ *proto.PublishRequest) (*proto.PublishResponse, error) {
+func (nopPublisher) Publish(_ context.Context, _ *proto.Event) (*proto.PublishResponse, error) {
 	return &proto.PublishResponse{Success: true}, nil
 }
+
+func (nopPublisher) Topic() string { return pubsub.TopicRoom }
 
 func newTimeoutTestGame() *Game {
 	gameArgs := &dao.GameArgs{

--- a/room_server/worker/testing/mock_game_creator.go
+++ b/room_server/worker/testing/mock_game_creator.go
@@ -49,3 +49,18 @@ func (mr *MockGameCreatorMockRecorder) CreateGameAndRun(players, gameType, compl
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGameAndRun", reflect.TypeOf((*MockGameCreator)(nil).CreateGameAndRun), players, gameType, completedMatchID)
 }
+
+// CreatePVPGameAndRun mocks base method.
+func (m *MockGameCreator) CreatePVPGameAndRun(players []types.PlayerAddress, completedMatchID int64) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreatePVPGameAndRun", players, completedMatchID)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreatePVPGameAndRun indicates an expected call of CreatePVPGameAndRun.
+func (mr *MockGameCreatorMockRecorder) CreatePVPGameAndRun(players, completedMatchID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePVPGameAndRun", reflect.TypeOf((*MockGameCreator)(nil).CreatePVPGameAndRun), players, completedMatchID)
+}

--- a/rpc/client/pubsub.go
+++ b/rpc/client/pubsub.go
@@ -48,22 +48,6 @@ func (c *PubSubClient) Close() error {
 	return nil
 }
 
-func (c *PubSubClient) Publish(topic string, event *pb.Event, metadata map[string]string) error {
-	if c.stream == nil {
-		return fmt.Errorf("stream is nil")
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	pub := pubsub.NewStreamPublisher(c.stream)
-	req := &pb.PublishRequest{Topic: topic, Event: event, Metadata: metadata}
-	resp, err := pub.Publish(ctx, req)
-	if err != nil {
-		return fmt.Errorf("failed to publish: %w", err)
-	}
-	log.Debugw("pubsub published", "message_id", resp.MessageId, "topic", topic, "subscriber_count", resp.SubscriberCount)
-	return nil
-}
-
 // Subscribe listens on TopicRoom and TopicLobby via Redis streams, filtering by Receivers.
 func (c *PubSubClient) Subscribe(subscriberID string, self *pb.PlayerAddress, evtChan chan *pb.Event, errChan chan error) error {
 	if c.eventBus == nil {


### PR DESCRIPTION
- update room v3 contract integration to include tournament ID and tier number across room server, chain workers, and RPC interfaces
- remove obsolete game constants/status paths and clean up redundant worker/testing code
- refactor related lobby-room coordination logic (queue, match, game creator, and tournament coordinator touchpoints) to match the new room flow
- regenerate/update RPC contract artifacts (`rpc.proto` / `rpc.pb.go`) and room contract bindings (`room_v3.abi` / `room_v3.go`)
