### PR TITLE
feat(room-server): add contract inspector and optimize tx pool cleanup batching

### DIFF
--- a/cmd/ele-tools/chain_tx_pool_cleanup.go
+++ b/cmd/ele-tools/chain_tx_pool_cleanup.go
@@ -19,6 +19,7 @@ var (
 	chainTxPoolCleanupDays    int
 	chainTxPoolCleanupExecute bool
 	chainTxPoolCleanupBatch   int
+	chainTxPoolCleanupSleep   time.Duration
 )
 
 var chainTxPoolCleanupCmd = &cobra.Command{
@@ -75,30 +76,38 @@ By default this is a dry-run that only prints the count; pass --execute to actua
 			return
 		}
 
-		type idRow struct{ ID uint }
+		type batchBoundary struct {
+			LastID uint
+		}
 		var deleted int64
 		for {
-			var rows []idRow
-			err := q.Select("id").Order("id").Limit(chainTxPoolCleanupBatch).Find(&rows).Error
+			batchScope := q.Select("id").Order("id").Limit(chainTxPoolCleanupBatch)
+			var boundary batchBoundary
+			err := db.Get().
+				Table("(?) AS batch_ids", batchScope).
+				Select("MAX(id) AS last_id").
+				Scan(&boundary).Error
 			if err != nil {
-				fmt.Printf("Failed to load batch ids: %v\n", err)
+				fmt.Printf("Failed to resolve batch boundary id: %v\n", err)
 				os.Exit(1)
 			}
-			if len(rows) == 0 {
+			if boundary.LastID == 0 {
 				break
 			}
 
-			ids := make([]uint, 0, len(rows))
-			for i := range rows {
-				ids = append(ids, rows[i].ID)
-			}
-
-			res := db.Get().Unscoped().Where("id IN ?", ids).Delete(&dao.ChainTxPoolItem{})
+			res := db.Get().Unscoped().
+				Where("deleted_at IS NOT NULL").
+				Where("deleted_at < ?", before).
+				Where("id <= ?", boundary.LastID).
+				Delete(&dao.ChainTxPoolItem{})
 			if res.Error != nil {
 				fmt.Printf("Failed to delete batch: %v\n", res.Error)
 				os.Exit(1)
 			}
 			deleted += res.RowsAffected
+			if chainTxPoolCleanupSleep > 0 {
+				time.Sleep(chainTxPoolCleanupSleep)
+			}
 		}
 
 		fmt.Printf("Deleted %d chain_tx_pool_items row(s)\n", deleted)
@@ -115,6 +124,7 @@ func init() {
 
 	chainTxPoolCleanupCmd.Flags().BoolVar(&chainTxPoolCleanupExecute, "execute", false, "actually delete rows (default: dry-run)")
 	chainTxPoolCleanupCmd.Flags().IntVar(&chainTxPoolCleanupBatch, "batch", 5000, "batch size for deletes")
+	chainTxPoolCleanupCmd.Flags().DurationVar(&chainTxPoolCleanupSleep, "sleep-interval", 0, "sleep duration between delete batches (e.g. 200ms, 1s)")
 }
 
 func parseFlexibleTime(s string) (time.Time, error) {

--- a/cmd/ele-tools/contract.go
+++ b/cmd/ele-tools/contract.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+
+	contract "github.com/CryptoElementals/common/contracts"
+	"github.com/CryptoElementals/common/config"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/spf13/cobra"
+)
+
+var (
+	contractInspectConfigPath string
+	contractInspectRPC        string
+	contractInspectAddress    string
+	contractInspectGameID     int64
+)
+
+var contractCmd = &cobra.Command{
+	Use:   "contract",
+	Short: "Contract inspection tools",
+}
+
+var contractInspectCmd = &cobra.Command{
+	Use:   "inspect",
+	Short: "Inspect RoomV3 roomData by game id",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runContractInspect(); err != nil {
+			fmt.Printf("inspect contract failed: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(contractCmd)
+	contractCmd.AddCommand(contractInspectCmd)
+
+	contractInspectCmd.Flags().StringVarP(&contractInspectConfigPath, "config", "c", "", "room-server config file path")
+	contractInspectCmd.Flags().StringVar(&contractInspectRPC, "rpc", "", "chain HTTP RPC endpoint")
+	contractInspectCmd.Flags().StringVar(&contractInspectAddress, "contract-address", "", "RoomV3 contract address")
+	contractInspectCmd.Flags().Int64VarP(&contractInspectGameID, "game-id", "i", 0, "game id")
+	contractInspectCmd.MarkFlagRequired("game-id")
+}
+
+func runContractInspect() error {
+	if contractInspectConfigPath != "" {
+		if err := config.InitRSConfig(contractInspectConfigPath); err != nil {
+			return fmt.Errorf("load room-server config: %w", err)
+		}
+		if contractInspectRPC == "" {
+			contractInspectRPC = config.RSGConf.ChainCfg.HttpRpc
+		}
+		if contractInspectAddress == "" {
+			contractInspectAddress = config.RSGConf.ChainCfg.RoomV3ContractAddress
+		}
+	}
+
+	if contractInspectRPC == "" {
+		return fmt.Errorf("rpc is required (flag --rpc or room-server config chain.node.http-rpc)")
+	}
+	if contractInspectAddress == "" {
+		return fmt.Errorf("contract-address is required (flag --contract-address or room-server config chain.contract.room-v3-contract-address)")
+	}
+	if !common.IsHexAddress(contractInspectAddress) {
+		return fmt.Errorf("invalid contract-address: %s", contractInspectAddress)
+	}
+	if contractInspectGameID <= 0 {
+		return fmt.Errorf("game-id must be greater than 0")
+	}
+
+	client, err := ethclient.Dial(contractInspectRPC)
+	if err != nil {
+		return fmt.Errorf("dial rpc: %w", err)
+	}
+	defer client.Close()
+
+	roomCtr, err := contract.NewRoomV3Contract(common.HexToAddress(contractInspectAddress), client)
+	if err != nil {
+		return fmt.Errorf("create RoomV3 contract client: %w", err)
+	}
+
+	roomData, err := roomCtr.RoomData(nil, big.NewInt(contractInspectGameID))
+	if err != nil {
+		return fmt.Errorf("call roomData: %w", err)
+	}
+
+	fmt.Printf("RoomData(game-id=%d)\n", contractInspectGameID)
+	fmt.Printf("  current_round: %s\n", roomData.CurrentRound.String())
+	fmt.Printf("  current_card_index: %s\n", roomData.CurrentCardIndex.String())
+	fmt.Printf("  total_round: %s\n", roomData.TotalRound.String())
+	fmt.Printf("  total_card_index: %s\n", roomData.TotalCardIndex.String())
+	fmt.Printf("  creator: %s\n", roomData.Creator.Hex())
+	fmt.Printf("  player1_id: %s\n", roomData.Player1Id.String())
+	fmt.Printf("  player2_id: %s\n", roomData.Player2Id.String())
+	fmt.Printf("  player1_temp: %s\n", roomData.Player1Temp.Hex())
+	fmt.Printf("  player2_temp: %s\n", roomData.Player2Temp.Hex())
+	fmt.Printf("  launch_time_unix: %s\n", roomData.LaunchTime.String())
+	if roomData.LaunchTime.Sign() > 0 {
+		fmt.Printf("  launch_time_utc: %s\n", time.Unix(roomData.LaunchTime.Int64(), 0).UTC().Format(time.RFC3339))
+	}
+	fmt.Printf("  round_timeout: %s\n", roomData.RoundTimeout.String())
+	fmt.Printf("  initial_hp: %s\n", roomData.InitialHP.String())
+	fmt.Printf("  tournament: %s\n", roomData.Tournament.String())
+	fmt.Printf("  tier_no: %s\n", roomData.TierNo.String())
+
+	return nil
+}

--- a/room_server/worker/game/game_manager.go
+++ b/room_server/worker/game/game_manager.go
@@ -198,8 +198,6 @@ func (r *GameManager) createGameAndNotify(players []types.PlayerAddress, gameTyp
 	game := NewGame(r.ctx, players, r.publisher, r.roomChain, r.gameResultSettler, gameType, gameArgs)
 	game.gameInfo.ID = completedMatchID
 	game.gameInfo.QueueMatchID = completedMatchID
-	game.tournamentID = tournamentID
-	game.tierNo = tierNo
 	if gameType == proto.GameType_TOURNAMENT {
 		rr := uint32(game.gameInfo.GameArgs.MaxNormalRounds)
 		if rr == 0 {
@@ -213,6 +211,8 @@ func (r *GameManager) createGameAndNotify(players []types.PlayerAddress, gameTyp
 	}
 	gameID := game.gameInfo.ID
 	if err := r.executeOnGame(gameID, func(g *Game) error {
+		g.tournamentID = tournamentID
+		g.tierNo = tierNo
 		return g.bootstrapFirstTurnAfterQueueConfirmations()
 	}); err != nil {
 		return 0, err


### PR DESCRIPTION
- add a new `ele-tools contract inspect` command to read RoomV3 `roomData` by game id, with support for RPC/contract flags or room-server config defaults
- optimize `cleanup-tx-pool` batch deletion by using a boundary-id strategy and preserving cutoff filters in each delete batch
- add optional `--sleep-interval` to throttle cleanup batches and reduce database load
- fix tournament game bootstrap by assigning `tournamentID` and `tierNo` within `executeOnGame(...)` before first-turn bootstrap