### PR TITLE
fix(withdraw): align withdrawNonce signing and correct token/USDT/wei rates

### DIFF
--- a/cmd/ele-tools/contract_sign_withdraw.go
+++ b/cmd/ele-tools/contract_sign_withdraw.go
@@ -1,23 +1,31 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"math/big"
 	"os"
 	"strings"
 
+	contract "github.com/CryptoElementals/common/contracts"
+	"github.com/CryptoElementals/common/config"
 	"github.com/CryptoElementals/common/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/spf13/cobra"
 )
 
 var (
-	signWithdrawDepositAddr string
-	signWithdrawAmountWei   string
-	signWithdrawPlayerID    string
-	signWithdrawPrivKeyFile string
+	signWithdrawConfigPath      string
+	signWithdrawRPC             string
+	signWithdrawTokenCollector  string
+	signWithdrawWalletManager   string
+	signWithdrawDepositAddr     string
+	signWithdrawAmountWei       string
+	signWithdrawPlayerID        string
+	signWithdrawPrivKeyFile     string
 )
 
 var contractSignWithdrawCmd = &cobra.Command{
@@ -26,12 +34,16 @@ var contractSignWithdrawCmd = &cobra.Command{
 	Long: `Generate an ECDSA signature for TokenCollector._withdraw.
 
 Solidity checks:
-  payloadHash = keccak256(abi.encodePacked(depositAddr, amount, playerId))
+  nonce = withdrawNonce[playerId]
+  payloadHash = keccak256(abi.encodePacked(depositAddr, amount, playerId, nonce))
   ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", payloadHash))
   ecrecover(ethSignedHash, v, r, s) == depositAddr
 
 --deposit-addr must be Credited(playerId).depositAddr (the "to" in encodePacked) and must match the private key.
 --amount-wei must equal the withdraw amount passed on-chain / to ledger RequestWithdraw (in wei).
+
+Nonce is read from chain via TokenCollector.withdrawNonce(playerId). Provide --token-collector
+or --wallet-manager (resolved to collector via getWalletIndexForPlayerId + getWalletSlot).
 
 Outputs:
   signature_hex    0x-prefixed 65 bytes for HTTP API / chain Withdraw calldata
@@ -47,6 +59,10 @@ Outputs:
 func init() {
 	contractCmd.AddCommand(contractSignWithdrawCmd)
 
+	contractSignWithdrawCmd.Flags().StringVarP(&signWithdrawConfigPath, "config", "c", "", "chain-server config file path (defaults --rpc / --wallet-manager)")
+	contractSignWithdrawCmd.Flags().StringVar(&signWithdrawRPC, "rpc", "", "chain HTTP RPC endpoint")
+	contractSignWithdrawCmd.Flags().StringVar(&signWithdrawTokenCollector, "token-collector", "", "TokenCollector contract address")
+	contractSignWithdrawCmd.Flags().StringVar(&signWithdrawWalletManager, "wallet-manager", "", "WalletManager address (resolve TokenCollector when --token-collector omitted)")
 	contractSignWithdrawCmd.Flags().StringVar(&signWithdrawDepositAddr, "deposit-addr", "", "Credited.depositAddr (to in encodePacked); must match private key")
 	contractSignWithdrawCmd.Flags().StringVar(&signWithdrawAmountWei, "amount-wei", "", "withdraw amount in wei")
 	contractSignWithdrawCmd.Flags().StringVar(&signWithdrawPlayerID, "player-id", "", "player id")
@@ -59,6 +75,32 @@ func init() {
 }
 
 func runContractSignWithdraw() error {
+	if signWithdrawConfigPath != "" {
+		if err := config.InitCSConfig(signWithdrawConfigPath); err != nil {
+			return fmt.Errorf("load chain-server config: %w", err)
+		}
+		chains := config.CSGConf.EffectiveChains()
+		if signWithdrawRPC == "" && len(chains) > 0 {
+			signWithdrawRPC = chains[0].HttpRpc
+		}
+		if signWithdrawWalletManager == "" && config.CSGConf.WalletChain != nil {
+			signWithdrawWalletManager = config.CSGConf.WalletChain.WalletManagerAddress
+		}
+	}
+
+	if signWithdrawRPC == "" {
+		return fmt.Errorf("rpc is required (flag --rpc or chain-server config chains[].node.http-rpc)")
+	}
+	if signWithdrawTokenCollector == "" && signWithdrawWalletManager == "" {
+		return fmt.Errorf("token-collector or wallet-manager is required")
+	}
+	if signWithdrawTokenCollector != "" && !common.IsHexAddress(signWithdrawTokenCollector) {
+		return fmt.Errorf("invalid token-collector: %s", signWithdrawTokenCollector)
+	}
+	if signWithdrawWalletManager != "" && !common.IsHexAddress(signWithdrawWalletManager) {
+		return fmt.Errorf("invalid wallet-manager: %s", signWithdrawWalletManager)
+	}
+
 	if !common.IsHexAddress(signWithdrawDepositAddr) {
 		return fmt.Errorf("invalid deposit-addr: %s", signWithdrawDepositAddr)
 	}
@@ -87,16 +129,36 @@ func runContractSignWithdraw() error {
 		return fmt.Errorf("deposit-addr %s does not match private key address %s (must be Credited.depositAddr)", depositAddr.Hex(), signerAddr.Hex())
 	}
 
-	payloadHash, err := utils.TokenCollectorWithdrawPayloadHash(depositAddr, amountWei, playerID)
+	client, err := ethclient.Dial(signWithdrawRPC)
+	if err != nil {
+		return fmt.Errorf("dial rpc: %w", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	tokenCollectorAddr := common.HexToAddress(signWithdrawTokenCollector)
+	if tokenCollectorAddr == (common.Address{}) {
+		tokenCollectorAddr, err = contract.ResolvePlayerTokenCollectorAddress(ctx, client, common.HexToAddress(signWithdrawWalletManager), playerID)
+		if err != nil {
+			return fmt.Errorf("resolve token collector: %w", err)
+		}
+	}
+
+	nonce, err := contract.QueryWithdrawNonce(ctx, client, tokenCollectorAddr, playerID)
+	if err != nil {
+		return fmt.Errorf("query withdraw nonce: %w", err)
+	}
+
+	payloadHash, err := utils.TokenCollectorWithdrawPayloadHash(depositAddr, amountWei, playerID, nonce)
 	if err != nil {
 		return fmt.Errorf("payload hash: %w", err)
 	}
 
-	sig, err := utils.SignTokenCollectorWithdraw(depositAddr, amountWei, playerID, priv)
+	sig, err := utils.SignTokenCollectorWithdraw(depositAddr, amountWei, playerID, nonce, priv)
 	if err != nil {
 		return fmt.Errorf("sign withdraw payload: %w", err)
 	}
-	verified, err := utils.VerifyTokenCollectorWithdraw(depositAddr, amountWei, playerID, sig)
+	verified, err := utils.VerifyTokenCollectorWithdraw(depositAddr, amountWei, playerID, nonce, sig)
 	if err != nil {
 		return fmt.Errorf("verify signature: %w", err)
 	}
@@ -104,8 +166,10 @@ func runContractSignWithdraw() error {
 		return fmt.Errorf("local ecrecover verification failed")
 	}
 
+	fmt.Printf("token_collector=%s\n", tokenCollectorAddr.Hex())
 	fmt.Printf("deposit_addr=%s\n", depositAddr.Hex())
 	fmt.Printf("signer_address=%s\n", signerAddr.Hex())
+	fmt.Printf("withdraw_nonce=%s\n", nonce.String())
 	fmt.Printf("payload_hash=%s\n", payloadHash.Hex())
 	fmt.Printf("signature_len=%d\n", len(sig))
 	fmt.Printf("signature_hex=%s\n", "0x"+common.Bytes2Hex(sig))

--- a/contracts/token_collector_query.go
+++ b/contracts/token_collector_query.go
@@ -1,0 +1,80 @@
+package contract
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var withdrawNonceMethodID = crypto.Keccak256([]byte("withdrawNonce(uint256)"))[:4]
+
+// QueryWithdrawNonce reads TokenCollector.withdrawNonce(playerId) via eth_call.
+func QueryWithdrawNonce(ctx context.Context, caller bind.ContractCaller, tokenCollector common.Address, playerID *big.Int) (*big.Int, error) {
+	if caller == nil {
+		return nil, fmt.Errorf("contract caller is nil")
+	}
+	if playerID == nil {
+		return nil, fmt.Errorf("playerID is nil")
+	}
+	if tokenCollector == (common.Address{}) {
+		return nil, fmt.Errorf("token collector address is zero")
+	}
+
+	data := make([]byte, 0, 4+32)
+	data = append(data, withdrawNonceMethodID...)
+	data = append(data, common.LeftPadBytes(playerID.Bytes(), 32)...)
+
+	out, err := caller.CallContract(ctx, ethereum.CallMsg{To: &tokenCollector, Data: data}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("withdrawNonce call: %w", err)
+	}
+	if len(out) == 0 {
+		return big.NewInt(0), nil
+	}
+	return new(big.Int).SetBytes(out), nil
+}
+
+// ResolvePlayerTokenCollectorAddress returns the active TokenCollector for playerId via WalletManager.
+func ResolvePlayerTokenCollectorAddress(ctx context.Context, caller bind.ContractCaller, walletManager common.Address, playerID *big.Int) (common.Address, error) {
+	if caller == nil {
+		return common.Address{}, fmt.Errorf("contract caller is nil")
+	}
+	if playerID == nil {
+		return common.Address{}, fmt.Errorf("playerID is nil")
+	}
+	if walletManager == (common.Address{}) {
+		return common.Address{}, fmt.Errorf("wallet manager address is zero")
+	}
+
+	wm, err := NewWalletManagerContractCaller(walletManager, caller)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("create WalletManager client: %w", err)
+	}
+
+	opts := &bind.CallOpts{Context: ctx}
+	walletIndex, err := wm.GetWalletIndexForPlayerId(opts, playerID)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("getWalletIndexForPlayerId: %w", err)
+	}
+
+	slot, err := wm.GetWalletSlot(opts, walletIndex)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("getWalletSlot(%s): %w", walletIndex.String(), err)
+	}
+	if !slot.Exists {
+		return common.Address{}, fmt.Errorf("wallet slot %s does not exist for playerId=%s", walletIndex.String(), playerID.String())
+	}
+	if !slot.IsActive {
+		return common.Address{}, fmt.Errorf("wallet slot %s is not active for playerId=%s", walletIndex.String(), playerID.String())
+	}
+	if slot.CurrentAddress == (common.Address{}) {
+		return common.Address{}, fmt.Errorf("wallet slot %s has no current address for playerId=%s", walletIndex.String(), playerID.String())
+	}
+
+	return slot.CurrentAddress, nil
+}

--- a/contracts/wallet_token_e2e_test.go
+++ b/contracts/wallet_token_e2e_test.go
@@ -370,9 +370,13 @@ func TestTokenCollectorWithdraw(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("[before] recipient mock USDT balance (%s): %s", depositAddr.Hex(), formatWei18(recipientBefore))
 
-	sig, err := utils.SignTokenCollectorWithdraw(depositAddr, withdrawAmount, playerID, userPriv)
+	withdrawNonce, err := QueryWithdrawNonce(ctx, client, playerCollector.Address, playerID)
 	require.NoError(t, err)
-	t.Logf("withdraw signature: depositAddr signs encodePacked(to,amount,playerId) + EIP-191")
+	t.Logf("withdrawNonce(playerId=%s)=%s", playerID.String(), withdrawNonce.String())
+
+	sig, err := utils.SignTokenCollectorWithdraw(depositAddr, withdrawAmount, playerID, withdrawNonce, userPriv)
+	require.NoError(t, err)
+	t.Logf("withdraw signature: depositAddr signs encodePacked(to,amount,playerId,nonce) + EIP-191")
 
 	chainID := big.NewInt(testChainID)
 	auth, err := bind.NewKeyedTransactorWithChainID(adminPriv, chainID)

--- a/db/chain_token_ledger.go
+++ b/db/chain_token_ledger.go
@@ -133,7 +133,7 @@ func applyChainDepositEventTx(tx *gorm.DB, ev ChainTokenEventInput) (*ChainToken
 		return nil, fmt.Errorf("convert amount wei: %w", err)
 	}
 	if remainder, remErr := tokenunits.WeiToTokenRemainder(ev.AmountWei); remErr == nil && remainder.Sign() > 0 {
-		log.Warnf("chain token event tx=%s log=%d has wei remainder %s after /10^16",
+		log.Warnf("chain token event tx=%s log=%d has wei remainder %s after /10^15",
 			normalizedTxHash, ev.LogIndex, remainder.String())
 	}
 

--- a/db/chain_token_ledger_test.go
+++ b/db/chain_token_ledger_test.go
@@ -46,14 +46,14 @@ func TestApplyChainTokenEvent_DepositCreditsUserToken(t *testing.T) {
 	require.NoError(t, initMemDbSqlite())
 	require.NoError(t, MigrateMemDb())
 
-	const amountWei = "1000000000000000000" // 100 game tokens
+	const amountWei = "1000000000000000000" // 1000 game tokens
 	ev := chainDepositEvent(97, "0xtx1", 1, 42, amountWei)
 
 	result, err := ApplyChainTokenEvent(context.Background(), ev)
 	require.NoError(t, err)
 	require.Equal(t, ChainTokenEventApplyFinalized, result.Status)
-	require.Equal(t, int32(100), result.TokenDelta)
-	require.Equal(t, int32(100), result.NewBalance)
+	require.Equal(t, int32(1000), result.TokenDelta)
+	require.Equal(t, int32(1000), result.NewBalance)
 
 	dup, err := ApplyChainTokenEvent(context.Background(), ev)
 	require.NoError(t, err)
@@ -61,7 +61,7 @@ func TestApplyChainTokenEvent_DepositCreditsUserToken(t *testing.T) {
 
 	token, err := EnsureUserTokenByPlayerID(42)
 	require.NoError(t, err)
-	require.Equal(t, int32(100), token.TokenAmount)
+	require.Equal(t, int32(1000), token.TokenAmount)
 }
 
 func TestApplyChainTokenEvent_WithdrawDeductsUserToken(t *testing.T) {
@@ -76,19 +76,19 @@ func TestApplyChainTokenEvent_WithdrawDeductsUserToken(t *testing.T) {
 	result, err := ApplyChainTokenEvent(context.Background(), chainWithdrawEvent(97, "0xtxwd", 2, 7, withdrawWei))
 	require.NoError(t, err)
 	require.Equal(t, ChainTokenEventApplyFinalized, result.Status)
-	require.Equal(t, int32(-50), result.TokenDelta)
-	require.Equal(t, int32(50), result.NewBalance)
+	require.Equal(t, int32(-500), result.TokenDelta)
+	require.Equal(t, int32(500), result.NewBalance)
 }
 
 func TestApplyChainTokenEvent_WithdrawInsufficientBalanceFailed(t *testing.T) {
 	require.NoError(t, initMemDbSqlite())
 	require.NoError(t, MigrateMemDb())
 
-	depositWei := "500000000000000000" // 50 game tokens
+	depositWei := "500000000000000000" // 500 game tokens
 	_, err := ApplyChainTokenEvent(context.Background(), chainDepositEvent(97, "0xtxdep2", 1, 9, depositWei))
 	require.NoError(t, err)
 
-	withdrawWei := "1000000000000000000" // 100 game tokens
+	withdrawWei := "1000000000000000000" // 1000 game tokens
 	result, err := ApplyChainTokenEvent(context.Background(), chainWithdrawEvent(97, "0xtxwd2", 2, 9, withdrawWei))
 	require.NoError(t, err)
 	require.Equal(t, ChainTokenEventApplyFailed, result.Status)
@@ -96,7 +96,7 @@ func TestApplyChainTokenEvent_WithdrawInsufficientBalanceFailed(t *testing.T) {
 
 	token, err := EnsureUserTokenByPlayerID(9)
 	require.NoError(t, err)
-	require.Equal(t, int32(50), token.TokenAmount)
+	require.Equal(t, int32(500), token.TokenAmount)
 
 	dup, err := ApplyChainTokenEvent(context.Background(), chainWithdrawEvent(97, "0xtxwd2", 2, 9, withdrawWei))
 	require.NoError(t, err)
@@ -107,7 +107,7 @@ func TestCreatePendingWithdrawAndFinalize(t *testing.T) {
 	require.NoError(t, initMemDbSqlite())
 	require.NoError(t, MigrateMemDb())
 
-	const depositWei = "2000000000000000000" // 200 tokens
+	const depositWei = "2000000000000000000" // 2000 tokens
 	_, err := ApplyChainTokenEvent(context.Background(), chainDepositEvent(97, "0xdep3", 1, 11, depositWei))
 	require.NoError(t, err)
 
@@ -123,19 +123,19 @@ func TestCreatePendingWithdrawAndFinalize(t *testing.T) {
 
 	token, err := EnsureUserTokenByPlayerID(11)
 	require.NoError(t, err)
-	require.Equal(t, int32(200), token.TokenAmount)
+	require.Equal(t, int32(2000), token.TokenAmount)
 
 	require.NoError(t, UpdatePendingWithdrawTxHash(context.Background(), pending.RequestID, "0xtxpending", "0xcollector"))
 
 	result, err := FinalizeChainTokenWithdraw(context.Background(), chainWithdrawEvent(97, "0xtxpending", 3, 11, withdrawWei))
 	require.NoError(t, err)
 	require.Equal(t, ChainTokenEventApplyFinalized, result.Status)
-	require.Equal(t, int32(-50), result.TokenDelta)
-	require.Equal(t, int32(150), result.NewBalance)
+	require.Equal(t, int32(-500), result.TokenDelta)
+	require.Equal(t, int32(1500), result.NewBalance)
 
 	token, err = EnsureUserTokenByPlayerID(11)
 	require.NoError(t, err)
-	require.Equal(t, int32(150), token.TokenAmount)
+	require.Equal(t, int32(1500), token.TokenAmount)
 }
 
 func TestCreatePendingWithdrawInsufficientAvailableBalance(t *testing.T) {
@@ -167,14 +167,14 @@ func TestGetWithdrawableTokenAmountFullBalance(t *testing.T) {
 	require.NoError(t, initMemDbSqlite())
 	require.NoError(t, MigrateMemDb())
 
-	const depositWei = "1000000000000000000" // 100 tokens
+	const depositWei = "1000000000000000000" // 1000 tokens
 	_, err := ApplyChainTokenEvent(context.Background(), chainDepositEvent(97, "0xwd-full", 1, 30, depositWei))
 	require.NoError(t, err)
 
 	got, err := GetWithdrawableTokenAmount(context.Background(), 30)
 	require.NoError(t, err)
-	require.Equal(t, int32(100), got.WithdrawableTokenAmount)
-	require.Equal(t, int32(100), got.TokenAmount)
+	require.Equal(t, int32(1000), got.WithdrawableTokenAmount)
+	require.Equal(t, int32(1000), got.TokenAmount)
 	require.Equal(t, int32(0), got.LockedTokens)
 	require.Equal(t, int32(0), got.PendingWithdrawTokenAmount)
 }
@@ -183,7 +183,7 @@ func TestGetWithdrawableTokenAmountPendingWithdraw(t *testing.T) {
 	require.NoError(t, initMemDbSqlite())
 	require.NoError(t, MigrateMemDb())
 
-	const depositWei = "500000000000000000" // 50 tokens
+	const depositWei = "500000000000000000" // 500 tokens
 	_, err := ApplyChainTokenEvent(context.Background(), chainDepositEvent(97, "0xwd-pend", 1, 31, depositWei))
 	require.NoError(t, err)
 
@@ -194,17 +194,17 @@ func TestGetWithdrawableTokenAmountPendingWithdraw(t *testing.T) {
 
 	got, err := GetWithdrawableTokenAmount(context.Background(), 31)
 	require.NoError(t, err)
-	require.Equal(t, int32(10), got.WithdrawableTokenAmount)
-	require.Equal(t, int32(50), got.TokenAmount)
+	require.Equal(t, int32(100), got.WithdrawableTokenAmount)
+	require.Equal(t, int32(500), got.TokenAmount)
 	require.Equal(t, int32(0), got.LockedTokens)
-	require.Equal(t, int32(40), got.PendingWithdrawTokenAmount)
+	require.Equal(t, int32(400), got.PendingWithdrawTokenAmount)
 }
 
 func TestGetWithdrawableTokenAmountLockedTokens(t *testing.T) {
 	require.NoError(t, initMemDbSqlite())
 	require.NoError(t, MigrateMemDb())
 
-	const depositWei = "1000000000000000000" // 100 tokens
+	const depositWei = "1000000000000000000" // 1000 tokens
 	_, err := ApplyChainTokenEvent(context.Background(), chainDepositEvent(97, "0xwd-lock", 1, 32, depositWei))
 	require.NoError(t, err)
 
@@ -212,8 +212,8 @@ func TestGetWithdrawableTokenAmountLockedTokens(t *testing.T) {
 
 	got, err := GetWithdrawableTokenAmount(context.Background(), 32)
 	require.NoError(t, err)
-	require.Equal(t, int32(70), got.WithdrawableTokenAmount)
-	require.Equal(t, int32(100), got.TokenAmount)
+	require.Equal(t, int32(970), got.WithdrawableTokenAmount)
+	require.Equal(t, int32(1000), got.TokenAmount)
 	require.Equal(t, int32(30), got.LockedTokens)
 	require.Equal(t, int32(0), got.PendingWithdrawTokenAmount)
 }

--- a/internal/chainamount/amount.go
+++ b/internal/chainamount/amount.go
@@ -6,7 +6,7 @@ import (
 	"github.com/CryptoElementals/common/internal/tokenunits"
 )
 
-// WeiToGameDivisor is 10^16: 1 game token = 0.01 USDT = 10^16 wei.
+// WeiToGameDivisor is 10^15: 1 game token = 0.001 USDT = 10^15 wei (1000 tokens per 1 USDT).
 const WeiToGameDivisor int64 = tokenunits.TokenToWeiMul
 
 // WeiToGameToken converts on-chain wei to game token units.

--- a/internal/chainamount/amount_test.go
+++ b/internal/chainamount/amount_test.go
@@ -13,7 +13,7 @@ func TestWeiToGameToken(t *testing.T) {
 	oneTokenWei := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil).String()
 	delta, err := WeiToGameToken(oneTokenWei)
 	require.NoError(t, err)
-	require.Equal(t, int32(100), delta)
+	require.Equal(t, int32(1000), delta)
 
 	_, err = WeiToGameToken("0")
 	require.Error(t, err)
@@ -26,7 +26,7 @@ func TestWeiToGameToken(t *testing.T) {
 	remainderWei := new(big.Int).Add(base, big.NewInt(1)).String()
 	delta, err = WeiToGameToken(remainderWei)
 	require.NoError(t, err)
-	require.Equal(t, int32(100), delta)
+	require.Equal(t, int32(1000), delta)
 
 	rem, err := WeiToGameTokenRemainder(remainderWei)
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestGameTokenToWei(t *testing.T) {
 	t.Parallel()
 	wei, err := GameTokenToWei(1000)
 	require.NoError(t, err)
-	require.Equal(t, "10000000000000000000", wei)
+	require.Equal(t, "1000000000000000000", wei)
 
 	delta, err := WeiToGameToken(wei)
 	require.NoError(t, err)

--- a/internal/tokenunits/convert_test.go
+++ b/internal/tokenunits/convert_test.go
@@ -12,21 +12,21 @@ func TestConvertAllDirections(t *testing.T) {
 	spec := NewSpec()
 
 	t.Run("token_to_usdt", func(t *testing.T) {
-		amount, rem, err := spec.Convert(UnitToken, UnitUSDT, "100")
+		amount, rem, err := spec.Convert(UnitToken, UnitUSDT, "1000")
 		require.NoError(t, err)
 		require.Equal(t, "0", rem)
-		require.Equal(t, "1000000000000000000", amount) // 1 USDT smallest
+		require.Equal(t, "1", amount)
 	})
 
 	t.Run("token_to_wei", func(t *testing.T) {
-		amount, rem, err := spec.Convert(UnitToken, UnitWei, "100")
+		amount, rem, err := spec.Convert(UnitToken, UnitWei, "1000")
 		require.NoError(t, err)
 		require.Equal(t, "0", rem)
 		require.Equal(t, "1000000000000000000", amount)
 	})
 
 	t.Run("usdt_to_wei", func(t *testing.T) {
-		amount, rem, err := spec.Convert(UnitUSDT, UnitWei, "1000000000000000000")
+		amount, rem, err := spec.Convert(UnitUSDT, UnitWei, "1")
 		require.NoError(t, err)
 		require.Equal(t, "0", rem)
 		require.Equal(t, "1000000000000000000", amount)
@@ -36,21 +36,29 @@ func TestConvertAllDirections(t *testing.T) {
 		amount, rem, err := spec.Convert(UnitWei, UnitUSDT, "1000000000000000000")
 		require.NoError(t, err)
 		require.Equal(t, "0", rem)
-		require.Equal(t, "1000000000000000000", amount)
+		require.Equal(t, "1", amount)
 	})
 
 	t.Run("usdt_to_token", func(t *testing.T) {
-		amount, rem, err := spec.Convert(UnitUSDT, UnitToken, "1000000000000000000")
+		amount, rem, err := spec.Convert(UnitUSDT, UnitToken, "1")
 		require.NoError(t, err)
 		require.Equal(t, "0", rem)
-		require.Equal(t, "100", amount)
+		require.Equal(t, "1000", amount)
 	})
 
 	t.Run("wei_to_token", func(t *testing.T) {
 		amount, rem, err := spec.Convert(UnitWei, UnitToken, "1000000000000000000")
 		require.NoError(t, err)
 		require.Equal(t, "0", rem)
-		require.Equal(t, "100", amount)
+		require.Equal(t, "1000", amount)
+	})
+
+	t.Run("token_to_usdt_differs_from_token_to_wei", func(t *testing.T) {
+		usdt, _, err := spec.Convert(UnitToken, UnitUSDT, "1000")
+		require.NoError(t, err)
+		wei, _, err := spec.Convert(UnitToken, UnitWei, "1000")
+		require.NoError(t, err)
+		require.NotEqual(t, usdt, wei)
 	})
 }
 
@@ -61,7 +69,7 @@ func TestWeiToTokenRemainder(t *testing.T) {
 
 	delta, err := WeiToToken(remainderWei)
 	require.NoError(t, err)
-	require.Equal(t, int32(100), delta)
+	require.Equal(t, int32(1000), delta)
 
 	rem, err := WeiToTokenRemainder(remainderWei)
 	require.NoError(t, err)
@@ -72,7 +80,7 @@ func TestTokenToWeiRoundTrip(t *testing.T) {
 	t.Parallel()
 	wei, err := TokenToWei(1000)
 	require.NoError(t, err)
-	require.Equal(t, "10000000000000000000", wei)
+	require.Equal(t, "1000000000000000000", wei)
 
 	delta, err := WeiToToken(wei)
 	require.NoError(t, err)
@@ -82,12 +90,14 @@ func TestTokenToWeiRoundTrip(t *testing.T) {
 func TestRatesMatchDerived(t *testing.T) {
 	t.Parallel()
 	rates := DefaultSpec.Rates()
-	require.Equal(t, "1000000000000000000", rates.TokenToUsdt.Mul.String())
-	require.Equal(t, "100", rates.TokenToUsdt.Div.String())
-	require.Equal(t, "1", rates.UsdtToWei.Mul.String())
+	require.Equal(t, "1", rates.TokenToUsdt.Mul.String())
+	require.Equal(t, "1000", rates.TokenToUsdt.Div.String())
+	require.Equal(t, "1000000000000000000", rates.UsdtToWei.Mul.String())
 	require.Equal(t, "1", rates.UsdtToWei.Div.String())
-	require.Equal(t, "10000000000000000", rates.TokenToWei.Mul.String())
+	require.Equal(t, "1000000000000000", rates.TokenToWei.Mul.String())
 	require.Equal(t, "1", rates.TokenToWei.Div.String())
-	require.Equal(t, "100", rates.UsdtToToken.Mul.String())
-	require.Equal(t, "1000000000000000000", rates.UsdtToToken.Div.String())
+	require.Equal(t, "1000", rates.UsdtToToken.Mul.String())
+	require.Equal(t, "1", rates.UsdtToToken.Div.String())
+	require.Equal(t, "1", rates.WeiToUsdt.Mul.String())
+	require.Equal(t, "1000000000000000000", rates.WeiToUsdt.Div.String())
 }

--- a/internal/tokenunits/spec.go
+++ b/internal/tokenunits/spec.go
@@ -3,18 +3,16 @@ package tokenunits
 import "math/big"
 
 const (
-	// token -> usdt (smallest): amount * TokenToUsdtMul * UsdtToWeiMul / (TokenToUsdtDenom * UsdtToWeiDenom)
-	// 1 Token = TokenToUsdtMul / TokenToUsdtDenom USDT.
+	// 1 USDT = TokenToUsdtDenom game tokens (1000 tokens per 1 USDT).
 	TokenToUsdtMul   int64 = 1
-	TokenToUsdtDenom int64 = 100
+	TokenToUsdtDenom int64 = 1000
 
-	// usdt -> wei: amount * UsdtToWeiMul / UsdtToWeiDenom
-	// 1 USDT = UsdtToWeiMul / UsdtToWeiDenom wei (smallest on-chain unit).
+	// 1 USDT = UsdtToWeiMul / UsdtToWeiDenom wei on chain (ERC-20 18 decimals).
 	UsdtToWeiMul   int64 = 1_000_000_000_000_000_000 // 10^18
 	UsdtToWeiDenom int64 = 1
 
-	// token -> wei derived: TokenToUsdtMul * UsdtToWeiMul / (TokenToUsdtDenom * UsdtToWeiDenom)
-	TokenToWeiMul int64 = TokenToUsdtMul * UsdtToWeiMul / UsdtToWeiDenom / TokenToUsdtDenom // 10^16
+	// token -> wei: 1 token = TokenToWeiMul wei (10^15; 1000 tokens = 1 USDT = 10^18 wei).
+	TokenToWeiMul int64 = 1_000_000_000_000_000 // 10^15
 )
 
 // Unit identifies token amount denomination.
@@ -23,8 +21,8 @@ type Unit int
 const (
 	UnitUnspecified Unit = iota
 	UnitToken
-	UnitUSDT
-	UnitWei
+	UnitUSDT // whole USDT (1 = 1 USDT)
+	UnitWei  // on-chain wei (10^-18 USDT on 18-decimal ERC-20)
 )
 
 // MulDiv is a rational conversion factor: result = floor(amount * Mul / Div).
@@ -58,19 +56,25 @@ var DefaultSpec = NewSpec()
 
 func NewSpec() Spec {
 	tokenToUsdt := MulDiv{
-		Mul: big.NewInt(TokenToUsdtMul * UsdtToWeiMul / UsdtToWeiDenom),
+		Mul: big.NewInt(TokenToUsdtMul),
 		Div: big.NewInt(TokenToUsdtDenom),
+	}
+	usdtToToken := MulDiv{
+		Mul: big.NewInt(TokenToUsdtDenom),
+		Div: big.NewInt(1),
+	}
+	usdtToWei := MulDiv{
+		Mul: big.NewInt(UsdtToWeiMul),
+		Div: big.NewInt(UsdtToWeiDenom),
+	}
+	weiToUsdt := MulDiv{
+		Mul: big.NewInt(1),
+		Div: big.NewInt(UsdtToWeiMul),
 	}
 	tokenToWei := MulDiv{
 		Mul: big.NewInt(TokenToWeiMul),
 		Div: big.NewInt(1),
 	}
-	usdtToWei := MulDiv{Mul: big.NewInt(1), Div: big.NewInt(1)}
-	usdtToToken := MulDiv{
-		Mul: big.NewInt(TokenToUsdtDenom * UsdtToWeiDenom),
-		Div: big.NewInt(TokenToUsdtMul * UsdtToWeiMul),
-	}
-	weiToUsdt := usdtToWei
 	weiToToken := MulDiv{
 		Mul: big.NewInt(1),
 		Div: big.NewInt(TokenToWeiMul),
@@ -85,7 +89,6 @@ func NewSpec() Spec {
 		weiToToken:  weiToToken,
 	}
 }
-
 
 func (s Spec) Rates() Rates {
 	return Rates{

--- a/ledger_server/unit_test.go
+++ b/ledger_server/unit_test.go
@@ -11,10 +11,11 @@ func TestGetTokenUnitRates(t *testing.T) {
 	svc := NewService(nil, nil, 0)
 	resp := svc.GetTokenUnitRates()
 	require.NotNil(t, resp.GetTokenToUsdt())
-	require.Equal(t, "1000000000000000000", resp.GetTokenToUsdt().GetMul())
-	require.Equal(t, "100", resp.GetTokenToUsdt().GetDiv())
-	require.Equal(t, "1", resp.GetUsdtToWei().GetMul())
-	require.Equal(t, "10000000000000000", resp.GetTokenToWei().GetMul())
+	require.Equal(t, "1", resp.GetTokenToUsdt().GetMul())
+	require.Equal(t, "1000", resp.GetTokenToUsdt().GetDiv())
+	require.Equal(t, "1000000000000000000", resp.GetUsdtToWei().GetMul())
+	require.Equal(t, "1", resp.GetUsdtToWei().GetDiv())
+	require.Equal(t, "1000000000000000", resp.GetTokenToWei().GetMul())
 }
 
 func TestConvertTokenAmount(t *testing.T) {
@@ -22,7 +23,7 @@ func TestConvertTokenAmount(t *testing.T) {
 	resp, err := svc.ConvertTokenAmount(&proto.ConvertTokenAmountRequest{
 		FromUnit: proto.TokenAmountUnit_TOKEN_AMOUNT_UNIT_TOKEN,
 		ToUnit:   proto.TokenAmountUnit_TOKEN_AMOUNT_UNIT_WEI,
-		Amount:   "100",
+		Amount:   "1000",
 	})
 	require.NoError(t, err)
 	require.Equal(t, "1000000000000000000", resp.GetAmount())

--- a/ledger_server/withdraw_test.go
+++ b/ledger_server/withdraw_test.go
@@ -110,8 +110,8 @@ func TestGetWithdrawableTokenAmountService(t *testing.T) {
 		PlayerId: 60,
 	})
 	require.NoError(t, err)
-	require.Equal(t, int32(100), resp.GetWithdrawableTokenAmount())
-	require.Equal(t, int32(100), resp.GetTokenAmount())
+	require.Equal(t, int32(1000), resp.GetWithdrawableTokenAmount())
+	require.Equal(t, int32(1000), resp.GetTokenAmount())
 	require.Equal(t, int32(0), resp.GetLockedTokens())
 	require.Equal(t, int32(0), resp.GetPendingWithdrawTokenAmount())
 }

--- a/utils/signature.go
+++ b/utils/signature.go
@@ -11,12 +11,12 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-// SignTokenCollectorWithdraw matches TokenCollector._withdraw:
-// keccak256(abi.encodePacked(depositAddr, amount, playerId)) then EIP-191 ("\x19Ethereum Signed Message:\n32", hash).
+// SignTokenCollectorWithdraw matches TokenCollector._verifyWithdrawSignature:
+// keccak256(abi.encodePacked(depositAddr, amount, playerId, nonce)) then EIP-191 ("\x19Ethereum Signed Message:\n32", hash).
 // Returns a 65-byte ECDSA signature (r||s||v) with v in {27,28}, suitable for withdraw(playerId, amount, signature).
 // The recovered signer must equal depositAddr (Credited.depositAddr).
-func SignTokenCollectorWithdraw(depositAddr common.Address, amount, playerID *big.Int, privateKey *ecdsa.PrivateKey) ([]byte, error) {
-	payloadHash, err := TokenCollectorWithdrawPayloadHash(depositAddr, amount, playerID)
+func SignTokenCollectorWithdraw(depositAddr common.Address, amount, playerID, nonce *big.Int, privateKey *ecdsa.PrivateKey) ([]byte, error) {
+	payloadHash, err := TokenCollectorWithdrawPayloadHash(depositAddr, amount, playerID, nonce)
 	if err != nil {
 		return nil, err
 	}
@@ -31,18 +31,18 @@ func SignTokenCollectorWithdraw(depositAddr common.Address, amount, playerID *bi
 	return sig, nil
 }
 
-// TokenCollectorWithdrawPayloadHash is keccak256(abi.encodePacked(depositAddr, amount, playerId)).
-func TokenCollectorWithdrawPayloadHash(depositAddr common.Address, amount, playerID *big.Int) (common.Hash, error) {
-	return SolidityPackedKeccak256([]any{depositAddr, amount, playerID})
+// TokenCollectorWithdrawPayloadHash is keccak256(abi.encodePacked(depositAddr, amount, playerId, nonce)).
+func TokenCollectorWithdrawPayloadHash(depositAddr common.Address, amount, playerID, nonce *big.Int) (common.Hash, error) {
+	return SolidityPackedKeccak256([]any{depositAddr, amount, playerID, nonce})
 }
 
-// VerifyTokenCollectorWithdraw mirrors TokenCollector._withdraw ecrecover check:
+// VerifyTokenCollectorWithdraw mirrors TokenCollector._verifyWithdrawSignature ecrecover check:
 // signer(payloadHash) must equal depositAddr (Credited.depositAddr).
-func VerifyTokenCollectorWithdraw(depositAddr common.Address, amount, playerID *big.Int, signature []byte) (bool, error) {
+func VerifyTokenCollectorWithdraw(depositAddr common.Address, amount, playerID, nonce *big.Int, signature []byte) (bool, error) {
 	if len(signature) != crypto.SignatureLength {
 		return false, fmt.Errorf("signature must be %d bytes, got %d", crypto.SignatureLength, len(signature))
 	}
-	payloadHash, err := TokenCollectorWithdrawPayloadHash(depositAddr, amount, playerID)
+	payloadHash, err := TokenCollectorWithdrawPayloadHash(depositAddr, amount, playerID, nonce)
 	if err != nil {
 		return false, err
 	}

--- a/utils/withdraw_signature_test.go
+++ b/utils/withdraw_signature_test.go
@@ -15,13 +15,14 @@ func TestSignTokenCollectorWithdrawRecover(t *testing.T) {
 	depositAddr := crypto.PubkeyToAddress(priv.PublicKey)
 	amount := new(big.Int).Mul(big.NewInt(10), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
 	playerID := big.NewInt(1)
+	nonce := big.NewInt(0)
 
-	sig, err := SignTokenCollectorWithdraw(depositAddr, amount, playerID, priv)
+	sig, err := SignTokenCollectorWithdraw(depositAddr, amount, playerID, nonce, priv)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	ok, err := VerifyTokenCollectorWithdraw(depositAddr, amount, playerID, sig)
+	ok, err := VerifyTokenCollectorWithdraw(depositAddr, amount, playerID, nonce, sig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestSignTokenCollectorWithdrawRecover(t *testing.T) {
 		t.Fatal("VerifyTokenCollectorWithdraw returned false")
 	}
 
-	payloadHash, err := TokenCollectorWithdrawPayloadHash(depositAddr, amount, playerID)
+	payloadHash, err := TokenCollectorWithdrawPayloadHash(depositAddr, amount, playerID, nonce)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,5 +40,27 @@ func TestSignTokenCollectorWithdrawRecover(t *testing.T) {
 	}
 	if recovered != depositAddr {
 		t.Fatalf("recovered %s want %s", recovered.Hex(), depositAddr.Hex())
+	}
+}
+
+func TestSignTokenCollectorWithdrawNonceAffectsHash(t *testing.T) {
+	priv, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	depositAddr := crypto.PubkeyToAddress(priv.PublicKey)
+	amount := big.NewInt(1)
+	playerID := big.NewInt(42)
+
+	h0, err := TokenCollectorWithdrawPayloadHash(depositAddr, amount, playerID, big.NewInt(0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	h1, err := TokenCollectorWithdrawPayloadHash(depositAddr, amount, playerID, big.NewInt(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h0 == h1 {
+		t.Fatal("payload hash should change when nonce changes")
 	}
 }


### PR DESCRIPTION
## Summary

- **Token units**: Set explicit conversion rates — **1 USDT = 1000 game tokens**, and decouple **USDT** (whole units) from **wei** (on-chain 18-decimal). Updates `internal/tokenunits/spec.go` and related tests (`chainamount`, `db`, `ledger_server`).
- **Withdraw signature**: Align with `TokenCollector._verifyWithdrawSignature` by including `withdrawNonce[playerId]` in `abi.encodePacked(depositAddr, amount, playerId, nonce)`. Updates `utils/signature.go` and e2e withdraw test.
- **Chain helpers**: Add `contracts/token_collector_query.go` — `QueryWithdrawNonce` and `ResolvePlayerTokenCollectorAddress`.
- **ele-tools**: `contract sign-withdraw` fetches nonce live via RPC; supports `--token-collector` or `--wallet-manager` (and optional `-c` chain-server config).

## Commits

- `b69d14d` fix(tokenunits): set 1000 tokens per USDT and decouple USDT from wei
- `ee7921e` fix(withdraw): include withdrawNonce in signature and fetch from chain

## Conversion rates (after this PR)

| Direction   | Rate                          |
|------------|-------------------------------|
| Token → USDT | 1 token = 0.001 USDT (÷1000) |
| USDT → Token | 1 USDT = 1000 tokens         |
| USDT → Wei   | 1 USDT = 10¹⁸ wei            |
| Token → Wei  | 1 token = 10¹⁵ wei           |

## Test plan

- [ ] `go test ./internal/tokenunits/... ./internal/chainamount/... ./db/... ./utils/... -count=1`
- [ ] `go test ./ledger_server/... -count=1`
- [ ] `go build ./cmd/ele-tools/...`
- [ ] `ele-tools contract sign-withdraw` against testnet: verify `withdraw_nonce` is read from chain and `signature_verified=true`
- [ ] `grpcurl` `LedgerService/RequestWithdraw` with `signature_base64` from ele-tools succeeds
- [ ] (Optional) BSC testnet e2e: `go test ./contracts -run TestTokenCollectorWithdraw -v -count=1`